### PR TITLE
Fix #141: error escaping char arrays with > 1 rows

### DIFF
--- a/plotly/plotly_aux/m2json.m
+++ b/plotly/plotly_aux/m2json.m
@@ -25,8 +25,14 @@ function valstr = m2json(val)
         valstr = strrep(valstr, 'Inf', 'null');
         valstr = strrep(valstr, 'NaN', 'null');
     elseif ischar(val)
-         val = checkescape(val); %add escape characters
-         valstr = ['"' val '"'];
+         [r, ~] = size(val);
+         % We can't use checkescape() if we have ['abc'; 'xyz']
+         if r > 1
+             valstr = cell2json(cellstr(val));
+         else
+             val = checkescape(val); %add escape characters
+             valstr = ['"' val '"'];
+         end
     elseif islogical(val)
         if val
             valstr = 'true';


### PR DESCRIPTION
Edit m2json to check if input char arrays have more than 1 row. If so, convert to cell array using cellstr() and let cell2json escape the strings.