### PR TITLE
plotlyoffline: fix when filename is returned as a cellstr

### DIFF
--- a/plotly/plotly_offline_aux/plotlyoffline.m
+++ b/plotly/plotly_offline_aux/plotlyoffline.m
@@ -71,6 +71,7 @@ function response = plotlyoffline(plotlyfig)
     % template entire script
     offline_script = [dep_script env_script plotly_script]; 
     filename = plotlyfig.PlotOptions.FileName; 
+    if iscellstr(filename), filename = sprintf('%s ', filename{:}); end
     
     % remove the whitespace from the filename
     clean_filename = filename(filename~=' '); 


### PR DESCRIPTION
In some cases, the filename is obtained as a cellstr. This edit converts to a valid char filename to be used for local storage.