### PR TITLE
findColorbarAxis.m fix for new Matlab releases

### DIFF
--- a/plotly/plotlyfig_aux/helpers/findColorbarAxis.m
+++ b/plotly/plotlyfig_aux/helpers/findColorbarAxis.m
@@ -1,6 +1,11 @@
 function colorbarAxis = findColorbarAxis(obj,colorbarHandle)
-if isHG2
+if isHG2    
     colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'ColorbarPeerHandle'),colorbarHandle)),obj.State.Axis));
+    % If the above returns empty then we are on a more recent Matlab
+    % release where the appdata entry is called LayoutPeers
+    if isempty(colorbarAxisIndex)
+        colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'LayoutPeers'),colorbarHandle)),obj.State.Axis));
+    end
 else
     colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'LegendColorbarInnerList'),colorbarHandle) + ...
         isequal(getappdata(x.Handle,'LegendColorbarOuterList'),colorbarHandle)),obj.State.Axis));


### PR DESCRIPTION
Mathworks renamed the colorbar peer appdata entry in the axes object in some recent release. Hence fig2plotly fails when there is a colorbar (I tested 2019a and 2019b Matlab release). The suggested change fixes this problem.