### PR TITLE
plotlygetfile: make an HTTP GET request instead of a POST

### DIFF
--- a/plotly/plotly_aux/plotly_version.m
+++ b/plotly/plotly_aux/plotly_version.m
@@ -1,3 +1,3 @@
 function version = plotly_version()
-    version = '2.2.9';
+    version = '2.2.10';
 end

--- a/plotly/plotly_aux/plotlygetfile.m
+++ b/plotly/plotly_aux/plotlygetfile.m
@@ -22,7 +22,7 @@ function figure = plotlygetfile(file_owner, file_id)
 
     url = [domain, '/apigetfile/', file_owner, '/', num2str(file_id)];
 
-    [response_string, extras] = urlread2(url, 'Post', '', headers);
+    [response_string, extras] = urlread2(url, 'Get', '', headers);
     response_handler(response_string, extras);
     response_object = loadjson(response_string);
     figure = response_object.payload.figure;


### PR DESCRIPTION
Fix for https://github.com/plotly/streambed/issues/13968

The issue stems from the library doing an HTTP POST request instead of a GET. This might have worked in the past but now Chart studio complains that: `POST requests require a <code>Content-length</code> header.`.

cc @cldougl @BRONSOLO @nicolaskruchten 