### PR TITLE
Changed PlotOptions.Strip to false

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -56,7 +56,7 @@ classdef plotlyfig < handle
             obj.PlotOptions.WorldReadable = true;
             obj.PlotOptions.ShowURL = true;
             obj.PlotOptions.OpenURL = true;
-            obj.PlotOptions.Strip = true;
+            obj.PlotOptions.Strip = false;
             obj.PlotOptions.Visible = 'on';
             obj.PlotOptions.TriangulatePatch = false; 
             

--- a/plotly/plotlyfig_aux/handlegraphics/updateBar.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateBar.m
@@ -89,7 +89,7 @@ switch bar_data.BarLayout
     case 'grouped'
         obj.layout.barmode = 'group';
     case 'stacked'
-        obj.layout.barmode = 'stack';
+        obj.layout.barmode = 'relative';
 end
 
 %-------------------------------------------------------------------------%

--- a/plotly/plotlyfig_aux/helpers/extractLineMarker.m
+++ b/plotly/plotlyfig_aux/helpers/extractLineMarker.m
@@ -55,7 +55,7 @@ if ~strcmp(line_data.Marker,'none')
     end
     
     marker.symbol = marksymbol;
-    
+    marker.maxdisplayed=length(line_data.MarkerIndices)+1;
 end
 
 %-------------------------------------------------------------------------%


### PR DESCRIPTION
This fixes the following issue #210 thus, the branch name!

`bargroupgap` is correctly written out in the `obj.layout` in **updatebar.m**, but I think this gets stripped off eventually and so we don't get the correct bar width in the online plots. Turning off stripping for the plot options fixes this bug and possibly many others!