### PR TITLE
Added Kaleido

### DIFF
--- a/plotly/export_fig2/getKaleido.m
+++ b/plotly/export_fig2/getKaleido.m
@@ -1,0 +1,46 @@
+function status = getKaleido()
+status=0;
+kDir = fullfile(fileparts(mfilename('fullpath')),'..','kaleido');
+arch = computer('arch');
+plotlyJS = 'https://cdn.plot.ly/plotly-latest.min.js';
+
+if isunix()
+    if ismac()
+        if strcmp(arch,'maci64')
+            url = 'https://github.com/plotly/Kaleido/releases/download/v0.2.1/kaleido_mac_x64.zip';
+        else
+            url = 'https://github.com/plotly/Kaleido/releases/download/v0.2.1/kaleido_mac_arm64.zip';
+        end
+    else
+        if strcmp(arch,'glnxa64')
+            url = 'https://github.com/plotly/Kaleido/releases/download/v0.2.1/kaleido_linux_x64.zip';
+        else
+            url = 'https://github.com/plotly/Kaleido/releases/download/v0.2.1/kaleido_linux_arm64.zip';
+        end
+    end
+elseif ispc()
+    if strcmp(arch,'win64')
+        url = 'https://github.com/plotly/Kaleido/releases/download/v0.2.1/kaleido_win_x64.zip';
+    else
+        url = 'https://github.com/plotly/Kaleido/releases/download/v0.2.1/kaleido_win_x86.zip';
+    end
+else
+    fprintf('\nCouldn''t find a suitable version of "Kaleido" required for exporting plots, for your system\n');
+    fprintf('https://github.com/plotly/Kaleido/tags\n');
+    fprintf('Please download a suitable Kaleido version for your system, and unzip the files in plotly/Kaleido folder.\n\n');
+    return;
+end
+
+fprintf('\nTrying to download Kaleido executable and plotly javascript (one-time download)... please wait...');
+try
+    file = websave(fullfile(kDir,'kaleido.zip'),url);
+    websave(fullfile(kDir,'plotly-latest.min.js'),plotlyJS);
+catch
+    fprintf('\nFailed to download Kaleido.\n');
+    fprintf('https://github.com/plotly/Kaleido/tags\n');
+    fprintf('Please download a suitable Kaleido version for your system, and unzip the files in plotly/Kaleido folder.\n\n');
+    return;
+end
+unzip(file,kDir);
+status=1;
+fprintf(' Done\n\n');

--- a/plotly/export_fig2/write_image.m
+++ b/plotly/export_fig2/write_image.m
@@ -1,0 +1,93 @@
+function output = write_image(pfObj, imageFormat, filename, height, width, scale)
+
+% Function to write plotly figures to a supported image format, which are the following: "png", "jpg", "jpeg", "webp", "svg", "pdf", "eps", "json"
+
+debug=1;
+if nargin < 2
+    imageFormat='png';
+    filename='figure.png';
+    height=500;
+    width=800;
+    scale=1;
+end
+
+wd=fileparts(fileparts(mfilename('fullpath')));
+output=[];
+
+if ~isa(pfObj,'plotlyfig')
+    fprintf('\nError: Input is not a plotlyfig object.\n\n');
+    return
+end
+
+if isunix()
+    kExec = string(fullfile(wd,'kaleido','kaleido'));
+    cc="cat";
+else
+    kExec = string(fullfile(wd,'kaleido','kaleido.cmd'));
+    cc="type";
+end
+plyJsLoc = string(fullfile(wd,'kaleido','plotly-latest.min.js'));
+
+if ~isfile(kExec) || ~isfile(plyJsLoc)
+    status=getKaleido();
+else
+    status=1;
+end
+
+if status == 0 
+    return 
+end
+
+mjLoc = replace(string(fullfile(wd,'kaleido','etc','mathjax','MathJax.js')),'\','/');
+scope="plotly";
+
+
+% Prepare input plotly object for Kaleido
+q=struct();
+q.data.data = pfObj.data;
+q.data.layout = pfObj.layout;
+q.data.layout = rmfield(q.data.layout,'height');
+q.data.layout = rmfield(q.data.layout,'width');
+q.format = imageFormat;
+q.height = height;
+q.scale = scale;
+q.width = width;
+
+pfJson = native2unicode(jsonencode(q),'UTF-8');
+tFile = string(fullfile(wd,'kaleido','temp.txt'));
+f=fopen(tFile,'w');
+fprintf(f,"%s",pfJson);
+fclose(f);
+
+cmd=[cc," ",tFile," | ",kExec," ",scope," --plotlyjs='",plyJsLoc,"' ","--mathjax='file:///",mjLoc,"' --no-sandbox --disable-gpu --allow-file-access-from-files --disable-breakpad --disable-dev-shm-usage"];
+
+if debug
+    inputCmd=char(join(cmd,''));
+    fprintf('\nDebug info:\n%s\n\n',inputCmd);
+end
+
+[code,out]=system(char(join(cmd,'')));
+if debug
+    disp(out);
+end
+
+if code ~= 0
+    fprintf('\nFatal: Failed to run Kaleido.\n\n');
+    return;
+else
+    a=string(split(out,newline));
+    if a(end)==""
+        a(end)=[];
+    end
+    output = jsondecode(a(end));
+end
+
+if output.code ~= 0
+    fprintf('\nError: %s\n',output.message);
+else
+    out=unicode2native(output.result,'UTF-8');
+    out=base64decode(out);
+    f=fopen(filename,'wb');
+    fwrite(f,out);
+    fclose(f);
+end

--- a/plotly/kaleido/.gitignore
+++ b/plotly/kaleido/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Added Kaleido for exporting static images from Plotly JSON.
Everything is taken care of, but this still needs to be tested on Mac OS and Linux, and perhaps also on an older MATLAB version.

Simple usage:
```
write_image(<plotly figure object>)
```
plotly figure object is returned by the fig2plotly() function.

Complete usage:
```
write_image(<plotly figure object>, <image format>, <filename>, <image height>, <image width>, <image scaling factor>)
```

Note reviewers: If you plan on providing more than 1 argument to this function, please provide them all. I will change this behavior tomorrow. Until then, please try it and let me know your comments/suggestions/improvement ideas, etc.