### PR TITLE
fix legend issues  with pie3 code-examples in ssim_baselines/matlab/code-examples/data-distribution-plots/pie3/

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -704,7 +704,9 @@ classdef plotlyfig < handle
             
             % update legends
             for n = 1:obj.State.Figure.NumLegends
-                updateLegend(obj,n);
+                if ~strcmpi(obj.PlotOptions.TreatAs, 'pie3')
+                    updateLegend(obj,n);
+                end
             end
             
             % update colorbars

--- a/plotly/plotlyfig_aux/handlegraphics/updatePie3.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updatePie3.m
@@ -1,42 +1,52 @@
 function updatePie3(obj,plotIndex)
     
-    %-update according to patch or surface-%
-    if strcmpi(obj.State.Plot(plotIndex).Class, 'patch')
-        updatePatchPie3(obj, plotIndex);
-    else
-        updateSurfacePie3(obj, plotIndex);
-    end
+  %-update according to patch or surface-%
+  if strcmpi(obj.State.Plot(plotIndex).Class, 'patch')
+      updatePatchPie3(obj, plotIndex);
+  else
+      updateSurfacePie3(obj, plotIndex);
+  end
 
-    %-hide axis-x-%
-    obj.PlotOptions.scene.xaxis.title = '';
-    obj.PlotOptions.scene.xaxis.autotick = false;
-    obj.PlotOptions.scene.xaxis.zeroline = false;
-    obj.PlotOptions.scene.xaxis.showline = false;
-    obj.PlotOptions.scene.xaxis.showticklabels = false;
-    obj.PlotOptions.scene.xaxis.showgrid = false;
-    
-    %-hide axis-y-%
-    obj.PlotOptions.scene.yaxis.title = '';
-    obj.PlotOptions.scene.yaxis.autotick = false;
-    obj.PlotOptions.scene.yaxis.zeroline = false;
-    obj.PlotOptions.scene.yaxis.showline = false;
-    obj.PlotOptions.scene.yaxis.showticklabels = false;
-    obj.PlotOptions.scene.yaxis.showgrid = false;
-    
-    %-hide axis-z-%
-    obj.PlotOptions.scene.zaxis.title = '';
-    obj.PlotOptions.scene.zaxis.autotick = false;
-    obj.PlotOptions.scene.zaxis.zeroline = false;
-    obj.PlotOptions.scene.zaxis.showline = false;
-    obj.PlotOptions.scene.zaxis.showticklabels = false;
-    obj.PlotOptions.scene.zaxis.showgrid = false;
-    
-    %-put text-%
-    obj.data{plotIndex}.hoverinfo = 'text';
-    obj.data{plotIndex}.hovertext = obj.PlotOptions.perc;
+  %-hide axis-x-%
+  obj.PlotOptions.scene.xaxis.title = '';
+  obj.PlotOptions.scene.xaxis.autotick = false;
+  obj.PlotOptions.scene.xaxis.zeroline = false;
+  obj.PlotOptions.scene.xaxis.showline = false;
+  obj.PlotOptions.scene.xaxis.showticklabels = false;
+  obj.PlotOptions.scene.xaxis.showgrid = false;
+  
+  %-hide axis-y-%
+  obj.PlotOptions.scene.yaxis.title = '';
+  obj.PlotOptions.scene.yaxis.autotick = false;
+  obj.PlotOptions.scene.yaxis.zeroline = false;
+  obj.PlotOptions.scene.yaxis.showline = false;
+  obj.PlotOptions.scene.yaxis.showticklabels = false;
+  obj.PlotOptions.scene.yaxis.showgrid = false;
+  
+  %-hide axis-z-%
+  obj.PlotOptions.scene.zaxis.title = '';
+  obj.PlotOptions.scene.zaxis.autotick = false;
+  obj.PlotOptions.scene.zaxis.zeroline = false;
+  obj.PlotOptions.scene.zaxis.showline = false;
+  obj.PlotOptions.scene.zaxis.showticklabels = false;
+  obj.PlotOptions.scene.zaxis.showgrid = false;
+  
+  %-put text-%
+  obj.data{plotIndex}.hoverinfo = 'text';
+  obj.data{plotIndex}.hovertext = obj.PlotOptions.perc;
 
-    obj.layout = setfield(obj.layout,['scene' obj.PlotOptions.scene_anchor(end)], obj.PlotOptions.scene);
-    obj.data{plotIndex}.scene = obj.PlotOptions.scene_anchor;
+  %-update scene-%
+  obj.layout = setfield(obj.layout,['scene' obj.PlotOptions.scene_anchor(end)], obj.PlotOptions.scene);
+  obj.data{plotIndex}.scene = obj.PlotOptions.scene_anchor;
+  obj.data{plotIndex}.legendgroup = obj.PlotOptions.scene_anchor;
+
+  %-update legend-%
+  obj.layout.legend.tracegroupgap = 20;
+  obj.layout.legend.traceorder = 'grouped';
+  obj.layout.legend.bordercolor = 'rgb(200,200,200)';
+  obj.layout.legend.x = 0.8;
+  obj.layout.legend.y = 0.5;
+  obj.layout.legend.borderwidth = 0.5;
     
 end
 
@@ -53,15 +63,15 @@ function obj = updatePatchPie3(obj, patchIndex)
 
   %-get the percentage-%
   if ~any(nonzeros(patch_data.ZData))
-      t1 = atan2(patch_data.YData(2), patch_data.XData(2));
-      t2 = atan2(patch_data.YData(end-1), patch_data.XData(end-1));
-      
-      a = rad2deg(t2-t1);
-      if a < 0
-          a = a+360;
-      end
-      
-      obj.PlotOptions.perc = sprintf('%d %%', round(100*a/360));
+    t1 = atan2(patch_data.YData(2), patch_data.XData(2));
+    t2 = atan2(patch_data.YData(end-1), patch_data.XData(end-1));
+    
+    a = rad2deg(t2-t1);
+    if a < 0
+        a = a+360;
+    end
+    
+    obj.PlotOptions.perc = sprintf('%d %%', round(100*a/360));
   end
 
   %-CHECK FOR MULTIPLE AXES-%
@@ -86,14 +96,14 @@ function obj = updatePatchPie3(obj, patchIndex)
   %-patch x-%
   xdata = patch_data.XData;
   if isvector(xdata)
-      obj.data{patchIndex}.x = [xdata' xdata(1)];
+    obj.data{patchIndex}.x = [xdata' xdata(1)];
   else
-      xtemp = reshape(xdata,[],1);
-      xnew = [];
-      for n = 1:size(xdata,2)
-          xnew = [xnew ; xdata(:,n) ; xdata(1,n); NaN];
-      end
-      obj.data{patchIndex}.x = xnew;
+    xtemp = reshape(xdata,[],1);
+    xnew = [];
+    for n = 1:size(xdata,2)
+        xnew = [xnew ; xdata(:,n) ; xdata(1,n); NaN];
+    end
+    obj.data{patchIndex}.x = xnew;
   end
 
   %---------------------------------------------------------------------%
@@ -101,14 +111,14 @@ function obj = updatePatchPie3(obj, patchIndex)
   %-patch y-%
   ydata = patch_data.YData;
   if isvector(ydata)
-      obj.data{patchIndex}.y = [ydata' ydata(1)];
+    obj.data{patchIndex}.y = [ydata' ydata(1)];
   else
-      ytemp = reshape(ydata,[],1);
-      ynew = [];
-      for n = 1:size(ydata,2)
-          ynew = [ynew ; ydata(:,n) ; ydata(1,n); NaN];
-      end
-      obj.data{patchIndex}.y = ynew;
+    ytemp = reshape(ydata,[],1);
+    ynew = [];
+    for n = 1:size(ydata,2)
+        ynew = [ynew ; ydata(:,n) ; ydata(1,n); NaN];
+    end
+    obj.data{patchIndex}.y = ynew;
   end
 
   %---------------------------------------------------------------------%
@@ -117,23 +127,23 @@ function obj = updatePatchPie3(obj, patchIndex)
   zdata = patch_data.ZData;
 
   if isvector(ydata)
-      obj.data{patchIndex}.z = [zdata' zdata(1)];
+    obj.data{patchIndex}.z = [zdata' zdata(1)];
   else
-      ztemp = reshape(zdata,[],1);
-      znew = [];
-      for n = 1:size(zdata,2)
-          znew = [znew ; zdata(:,n) ; zdata(1,n); NaN];
-      end
-      obj.data{patchIndex}.z = znew;
+    ztemp = reshape(zdata,[],1);
+    znew = [];
+    for n = 1:size(zdata,2)
+        znew = [znew ; zdata(:,n) ; zdata(1,n); NaN];
+    end
+    obj.data{patchIndex}.z = znew;
   end
 
   %---------------------------------------------------------------------%
 
   %-patch name-%
   if ~isempty(patch_data.DisplayName)
-      obj.data{patchIndex}.name = patch_data.DisplayName;
+    obj.data{patchIndex}.name = patch_data.DisplayName;
   else
-      obj.data{patchIndex}.name = patch_data.DisplayName;
+    obj.data{patchIndex}.name = patch_data.DisplayName;
   end
 
   %---------------------------------------------------------------------%
@@ -144,17 +154,17 @@ function obj = updatePatchPie3(obj, patchIndex)
   %---------------------------------------------------------------------%
 
   %-patch fill-%
-  %     obj.data{patchIndex}.fill = 'tozeroy';
+  % obj.data{patchIndex}.fill = 'tozeroy';
 
   %-PATCH MODE-%
   if ~strcmpi('none', patch_data.Marker) && ~strcmpi('none', patch_data.LineStyle)
-      mode = 'lines+markers';
+    mode = 'lines+markers';
   elseif ~strcmpi('none', patch_data.Marker)
-      mode = 'markers';
+    mode = 'markers';
   elseif ~strcmpi('none', patch_data.LineStyle)
-      mode = 'lines';
+    mode = 'lines';
   else
-      mode = 'none';
+    mode = 'none';
   end
 
   obj.data{patchIndex}.mode = mode;
@@ -173,21 +183,19 @@ function obj = updatePatchPie3(obj, patchIndex)
 
   %-patch fillcolor-%
   fill = extractPatchFace(patch_data);
+  obj.data{patchIndex}.surfacecolor = fill.color;
 
-  if strcmp(obj.data{patchIndex}.type,'scatter')
-      obj.data{patchIndex}.fillcolor = fill.color; 
-  else
-      obj.data{patchIndex}.surfacecolor = fill.color;
+  if zdata(1) == 0
+    obj.data{patchIndex}.line.width = 3;
+    obj.data{patchIndex}.line.color = fill.color;
   end
 
   %---------------------------------------------------------------------%
 
   %-surfaceaxis-%
-  if strcmp(obj.data{patchIndex}.type,'scatter3d')
-      minstd = min([std(patch_data.XData) std(patch_data.YData) std(patch_data.ZData)]);
-      ind = find([std(patch_data.XData) std(patch_data.YData) std(patch_data.ZData)] == minstd)-1;
-      obj.data{patchIndex}.surfaceaxis = ind; 
-  end
+  minstd = min([std(patch_data.XData) std(patch_data.YData) std(patch_data.ZData)]);
+  ind = find([std(patch_data.XData) std(patch_data.YData) std(patch_data.ZData)] == minstd)-1;
+  obj.data{patchIndex}.surfaceaxis = ind;
 
   %-------------------------------------------------------------------------%
 
@@ -196,10 +204,10 @@ function obj = updatePatchPie3(obj, patchIndex)
   legInfo = get(leg.LegendInformation);
 
   switch legInfo.IconDisplayStyle
-      case 'on'
-          showleg = true;
-      case 'off'
-          showleg = false;
+    case 'on'
+      showleg = true;
+    case 'off'
+      showleg = false;
   end
 
   obj.data{patchIndex}.showlegend = showleg;
@@ -253,8 +261,8 @@ function obj = updateSurfacePie3(obj, surfaceIndex)
   len = length(cmap)-1;
 
   for c = 1:length(cmap)
-      col = 255 * cmap(c, :);
-      obj.data{surfaceIndex}.colorscale{c} = { (c-1)/len , ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'  ]  };
+    col = 255 * cmap(c, :);
+    obj.data{surfaceIndex}.colorscale{c} = { (c-1)/len , ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'  ]  };
   end
 
   obj.data{surfaceIndex}.surfacecolor = 255*(image_data.CData-1) / (obj.PlotOptions.nbars{xsource} - 1);
@@ -271,19 +279,19 @@ function obj = updateSurfacePie3(obj, surfaceIndex)
   ar = obj.PlotOptions.AspectRatio;
 
   if ~isempty(ar)
-      if ischar(ar)
-          scene.aspectmode = ar;
-      elseif isvector(ar) && length(ar) == 3
-          xar = ar(1);
-          yar = ar(2);
-          zar = ar(3);
-      end
+    if ischar(ar)
+      scene.aspectmode = ar;
+    elseif isvector(ar) && length(ar) == 3
+      xar = ar(1);
+      yar = ar(2);
+      zar = ar(3);
+    end
   else
 
-      %-define as default-%
-      xar = max(xdata(:));
-      yar = max(ydata(:));
-      zar = max([xar, yar]);
+    %-define as default-%
+    xar = max(xdata(:));
+    yar = max(ydata(:));
+    zar = max([xar, yar]);
   end
 
   fac1 = 0.75;
@@ -305,21 +313,21 @@ function obj = updateSurfacePie3(obj, surfaceIndex)
   ey = obj.PlotOptions.CameraEye;
 
   if ~isempty(ey)
-      if isvector(ey) && length(ey) == 3
-          scene.camera.eye.x = ey(1);
-          scene.camera.eye.y = ey(2);
-          scene.camera.eye.z = ey(3);
-      end
+    if isvector(ey) && length(ey) == 3
+      scene.camera.eye.x = ey(1);
+      scene.camera.eye.y = ey(2);
+      scene.camera.eye.z = ey(3);
+    end
   else
 
-      %-define as default-%
-      xey = - xar; if xey>0 xfac = -0.2; else xfac = 0.2; end
-      yey = - yar; if yey>0 yfac = -0.2; else yfac = 0.2; end
-      if zar>0 zfac = 0.2; else zfac = -0.2; end
-      
-      scene.camera.eye.x = xey + xfac*xey; 
-      scene.camera.eye.y = yey + yfac*yey;
-      scene.camera.eye.z = zar + zfac*zar;
+    %-define as default-%
+    xey = - xar; if xey>0 xfac = -0.2; else xfac = 0.2; end
+    yey = - yar; if yey>0 yfac = -0.2; else yfac = 0.2; end
+    if zar>0 zfac = 0.2; else zfac = -0.2; end
+    
+    scene.camera.eye.x = xey + xfac*xey; 
+    scene.camera.eye.y = yey + yfac*yey;
+    scene.camera.eye.z = zar + zfac*zar;
   end
 
   %-------------------------------------------------------------------------%
@@ -331,6 +339,7 @@ function obj = updateSurfacePie3(obj, surfaceIndex)
 
   %-surface name-%
   obj.data{surfaceIndex}.name = image_data.DisplayName;
+  obj.data{surfaceIndex-1}.name = image_data.DisplayName;
 
   %-------------------------------------------------------------------------%
 
@@ -348,13 +357,14 @@ function obj = updateSurfacePie3(obj, surfaceIndex)
   legInfo = get(leg.LegendInformation);
 
   switch legInfo.IconDisplayStyle
-      case 'on'
-          showleg = true;
-      case 'off'
-          showleg = false;
+    case 'on'
+      showleg = true;
+    case 'off'
+      showleg = false;
   end
 
-  obj.data{surfaceIndex}.showlegend = showleg;
+  obj.data{surfaceIndex-1}.showlegend = showleg;
+  obj.data{surfaceIndex}.showlegend = false;
 
   %-------------------------------------------------------------------------%
 end


### PR DESCRIPTION
This PR fix issues related to legend using `pie3` function. Specifically working with `plot_2_0_compare_two_pie_charts.m` example in https://github.com/plotly/ssim_baselines/tree/main/matlab/code-examples/data-distribution-plots/pie3

Code to test 

```
y2010 = [50 0 100 95];
y2011 = [65 22 97 120];
labels = {'Investments','Cash','Operations','Sales'};
t = tiledlayout (2,1);
ax1 = nexttile;
pie3(ax1,y2010)
title('2010')
legend(labels)

ax2 = nexttile;
pie3(ax2,y2011)
title('2011')
legend(labels);

f = fig2plotly(gcf, 'offline', 0, 'TreatAs', 'pie3');
```

Result must look as follow

<img width="1278" alt="Screen Shot 2021-08-27 at 9 16 15 AM" src="https://user-images.githubusercontent.com/56391490/131133274-d37ecef1-84e9-4c56-b612-9350594744a4.png">

Link to `chart-studio` bellow

https://chart-studio.plotly.com/~galvisgilberto/3708/_2010/#/
