### PR TITLE
add quality and zmin parameter to improve elapsed time working with steamtube function

### DIFF
--- a/plotly/plotly_aux/plotly.m
+++ b/plotly/plotly_aux/plotly.m
@@ -10,7 +10,7 @@ function [response] = plotly(varargin)
 %
 % For full documentation and examples, see https://plot.ly/api
 origin = 'plot';
-offline = true;
+offline = false;
 struct_provided = false;
 
 if isstruct(varargin{end})

--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -57,6 +57,8 @@ classdef plotlyfig < handle
             obj.PlotOptions.AspectRatio = [];
             obj.PlotOptions.CameraEye = [];
             obj.PlotOptions.is_headmap_axis = false;
+            obj.PlotOptions.Quality = -1;
+            obj.PlotOptions.Zmin = [];
             
             % offline options
             obj.PlotOptions.Offline = true;
@@ -223,6 +225,12 @@ classdef plotlyfig < handle
                         end
                         if(strcmpi(varargin{a},'CameraEye'))
                             obj.PlotOptions.CameraEye = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'Quality'))
+                            obj.PlotOptions.Quality = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'Zmin'))
+                            obj.PlotOptions.Zmin = varargin{a+1};
                         end
                     end
             end


### PR DESCRIPTION
This PR fix issues with:

1. online mode
2. elapsed time working with streamtube function by adding two optional parameter: 

- `quality`: percentage of quality to downsampling the data sent to plotly
- `zmin`: to remove data lest than zmin

NOTE: To work with this new modifications `TreatAs` optional parameter must set to `'streamtube'`

Example of usage:

```
load wind
[sx,sy,sz] = meshgrid(80,20:10:50,0:5:15);
streamtube(x,y,z,u,v,w,sx,sy,sz);
view(3);
axis tight
shading interp;
camlight; 
lighting gouraud

fig2plotly(gcf(), 'offline', 0, 'TreatAs', 'streamtube', 'quality', 30, 'Zmin', 6);
```

Results looks as follow (link to chart-studio)
https://chart-studio.plotly.com/~galvisgilberto/3764/#/