### PR TITLE
fixing issues related to tick-values-labels and colorbar

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -87,7 +87,7 @@ classdef plotlyfig < handle
             end
             
             %-PlotlyDefaults-%
-            obj.PlotlyDefaults.MinTitleMargin = 80;
+            obj.PlotlyDefaults.MinTitleMargin = 10;
             obj.PlotlyDefaults.TitleHeight = 0.01;
             obj.PlotlyDefaults.TitleFontSizeIncrease = 40; 
             obj.PlotlyDefaults.FigureIncreaseFactor = 1.5;
@@ -788,7 +788,6 @@ classdef plotlyfig < handle
                     end
                 catch
                     % TODO to the future
-                    % disp('catch at line 679 in plotlyfig.m file')
                 end
             end
             
@@ -1108,7 +1107,7 @@ classdef plotlyfig < handle
                         ||  strcmpi(fieldname,'legend') ||  strcmpi(fieldname,'histogram')...
                         ||  strcmpi(fieldname,'scatter') ||  strcmpi(fieldname,'line')...
                         ||  strcmpi(fieldname,'scattergeo') ||  strcmpi(fieldname,'scattermapbox')...
-                        ||  strcmpi(fieldname,'scatterternary')...
+                        ||  strcmpi(fieldname,'scatterternary') ||  strcmpi(fieldname,'colorbar')...
                         )
                         fprintf(['\nWhoops! ' exception.message(1:end-1) ' in ' fieldname '\n\n']);
                     end

--- a/plotly/plotlyfig_aux/core/updateColorbar.m
+++ b/plotly/plotlyfig_aux/core/updateColorbar.m
@@ -1,362 +1,343 @@
 function obj = updateColorbar(obj,colorbarIndex)
 
-% title: ...[DONE]
-% titleside: ...[DONE]
-% titlefont: ...[DONE]
-% thickness: ...[DONE]
-% thicknessmode: ...[DONE]
-% len: ...[DONE]
-% lenmode: ...[DONE]
-% x: ...[DONE]
-% y: ...[DONE]
-% autotick: ...[DONE]
-% nticks: ...[DONE]
-% ticks: ...[DONE]
-% showticklabels: ...[DONE]
-% tick0: ...[DONE]
-% dtick: ...[DONE]
-% ticklen: ...[DONE]
-% tickwidth: ...[DONE]
-% tickcolor: ...[DONE]
-% tickangle: ...[NOT SUPPORTED IN MATLAB]
-% tickfont: ...[DONE]
-% exponentformat: ...[DONE]
-% showexponent: ...[NOT SUPPORTED IN MATLAB]
-% xanchor: ...[DONE]
-% yanchor: ...[DONE]
-% bgcolor: ...[DONE]
-% outlinecolor: ...[DONE]
-% outlinewidth: ...[DONE]
-% borderwidth: ...[NOT SUPPORTED IN MATLAB]
-% bordercolor: ...[NOT SUPPORTED IN MATLAB]
-% xpad: ...[DONE]
-% ypad: ...[DONE]
+    % title: ...[DONE]
+    % titleside: ...[DONE]
+    % titlefont: ...[DONE]
+    % thickness: ...[DONE]
+    % thicknessmode: ...[DONE]
+    % len: ...[DONE]
+    % lenmode: ...[DONE]
+    % x: ...[DONE]
+    % y: ...[DONE]
+    % autotick: ...[DONE]
+    % nticks: ...[DONE]
+    % ticks: ...[DONE]
+    % showticklabels: ...[DONE]
+    % tick0: ...[DONE]
+    % dtick: ...[DONE]
+    % ticklen: ...[DONE]
+    % tickwidth: ...[DONE]
+    % tickcolor: ...[DONE]
+    % tickangle: ...[NOT SUPPORTED IN MATLAB]
+    % tickfont: ...[DONE]
+    % exponentformat: ...[DONE]
+    % showexponent: ...[NOT SUPPORTED IN MATLAB]
+    % xanchor: ...[DONE]
+    % yanchor: ...[DONE]
+    % bgcolor: ...[DONE]
+    % outlinecolor: ...[DONE]
+    % outlinewidth: ...[DONE]
+    % borderwidth: ...[NOT SUPPORTED IN MATLAB]
+    % bordercolor: ...[NOT SUPPORTED IN MATLAB]
+    % xpad: ...[DONE]
+    % ypad: ...[DONE]
 
-%-FIGURE STRUCTURE-%
-figure_data = get(obj.State.Figure.Handle);
+    %-FIGURE STRUCTURE-%
+    figureData = get(obj.State.Figure.Handle);
 
-%-PLOT DATA STRUCTURE- %
-try
-    colorbar_data = get(obj.State.Colorbar(colorbarIndex).Handle);
-catch
-    disp('here');
-end
+    %-PLOT DATA STRUCTURE- %
+    try
+        colorbarData = get(obj.State.Colorbar(colorbarIndex).Handle);
+    catch
+        disp('could not get colorbar data');
+    end
 
-%-STANDARDIZE UNITS-%
-colorbarunits = colorbar_data.Units;
-set(obj.State.Colorbar(colorbarIndex).Handle,'Units','normalized');
+    %-STANDARDIZE UNITS-%
+    colorbarUnits = colorbarData.Units;
+    set(obj.State.Colorbar(colorbarIndex).Handle,'Units','normalized');
 
-%-------------------------------------------------------------------------%
+    %-------------------------------------------------------------------------%
 
-%-x anchor-%
-colorbar.xanchor = 'left';
+    %-variable initialization-%
+    if isHG2
+        outlineColor = [0 0 0];
+    else
+        if colorbarData.Position(4) > colorbarData.Position(3)
+            outlineColor = 255*colorbarData.YColor;
+        else
+            outlineColor = 255*colorbarData.XColor;
+        end
+    end
 
-%-------------------------------------------------------------------------%
+    outlineColor = sprintf('rgb(%f,%f,%f)', outlineColor);
+    lineWidth = colorbarData.LineWidth*obj.PlotlyDefaults.AxisLineIncreaseFactor;
+    tickLength = min(obj.PlotlyDefaults.MaxTickLength,...
+        max(colorbarData.TickLength(1)*colorbarData.Position(3)*obj.layout.width,...
+        colorbarData.TickLength(1)*colorbarData.Position(4)*obj.layout.height));
 
-%-y anchor-%
-colorbar.yanchor = 'bottom';
+    %-------------------------------------------------------------------------%
 
-%-------------------------------------------------------------------------%
+    %-colorbar placement-%
+    colorbar.x = colorbarData.Position(1);
+    colorbar.y = colorbarData.Position(2);
+    colorbar.len = colorbarData.Position(4);
+    colorbar.thickness = colorbarData.Position(3);
 
-%-x position-%
-colorbar.x = colorbar_data.Position(1);
+    colorbar.xpad = obj.PlotlyDefaults.MarginPad;
+    colorbar.ypad = obj.PlotlyDefaults.MarginPad;
+    colorbar.xanchor = 'left';
+    colorbar.yanchor = 'bottom';
 
-%-------------------------------------------------------------------------%
-
-%-y position-%
-colorbar.y = colorbar_data.Position(2);
-
-%-------------------------------------------------------------------------%
-
-%-exponent format-%
-colorbar.exponentformat = obj.PlotlyDefaults.ExponentFormat;
-
-%-------------------------------------------------------------------------%
-
-% get colorbar title and labels
-if isHG2
-    colorbar_title = colorbar_data.Label;
-    colorbar_title_data = get(colorbar_title);
-    colorbar_ylabel = colorbar_data.Label;
-    colorbar_ylabel_data = get(colorbar_data.Label);
-    colorbar_xlabel_data.String = [];
-else
-    colorbar_title = colorbar_data.Title;
-    colorbar_title_data = get(colorbar_title);
-    colorbar_xlabel = colorbar_data.XLabel;
-    colorbar_xlabel_data = get(colorbar_xlabel);
-    colorbar_ylabel = colorbar_data.YLabel;
-    colorbar_ylabel_data = get(colorbar_ylabel);
-end
-
-%-colorbar title-%
-if ~isempty(colorbar_title_data.String)
-    %-colorbar title-%
-    colorbar.title = parseString(colorbar_title_data.String,colorbar_title_data.Interpreter);
-elseif ~isempty(colorbar_xlabel_data.String)
-    %-colorbar title-%
-    colorbar.title = parseString(colorbar_xlabel_data.String,colorbar_xlabel_data.Interpreter);
-elseif ~isempty(colorbar_ylabel_data.String)
-    %-colorbar title-%
-    colorbar.title = parseString(colorbar_ylabel_data.String,colorbar_ylabel_data.Interpreter);
+    colorbar.outlinewidth = lineWidth;
+    colorbar.outlinecolor = outlineColor;
+    colorbar.exponentformat = obj.PlotlyDefaults.ExponentFormat;
+    colorbar.thicknessmode = 'fraction';
+    colorbar.lenmode = 'fraction';
     
-end
+    %-------------------------------------------------------------------------%
 
+    %-tick setings-%
+    colorbar.tickcolor = outlineColor;
+    colorbar.tickfont.color = outlineColor;
+    colorbar.tickfont.size = colorbarData.FontSize;
+    colorbar.tickfont.family = matlab2plotlyfont(colorbarData.FontName);
+    colorbar.ticklen = tickLength;
+    colorbar.tickwidth = lineWidth;
 
-%-------------------------------------------------------------------------%
+    %-------------------------------------------------------------------------%
 
-%-STANDARDIZE UNITS-%
-titleunits = colorbar_title_data.Units;
-titlefontunits = colorbar_title_data.FontUnits;
-ylabelunits = colorbar_ylabel_data.Units;
-ylabelfontunits = colorbar_ylabel_data.FontUnits;
-set(colorbar_title,'Units','data');
-set(colorbar_ylabel,'Units','data');
-set(colorbar_ylabel,'FontUnits','points');
-if ~isHG2
-    xlabelunits = colorbar_xlabel_data.Units;
-    xlabelfontunits = colorbar_xlabel_data.FontUnits;
-    set(colorbar_title,'FontUnits','points');
-    set(colorbar_xlabel,'Units','data');
-    set(colorbar_xlabel,'FontUnits','points');
-end
+    %-get colorbar title and labels-%
+    colorbarTitle = colorbarData.Label;
 
-
-if ~isempty(colorbar_title_data.String)
-    %-colorbar titleside-%
-    colorbar.titleside = 'top';
-    %-colorbar titlefont family-%:
-    colorbar.titlefont.family = matlab2plotlyfont(colorbar_title_data.FontName);
-    %-colorbar titlefont color-%
-    col = 255*colorbar_title_data.Color;
-    colorbar.titlefont.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
-    %-colorbar titlefont size-%
-    colorbar.titlefont.size = colorbar_title_data.FontSize;
-elseif ~isempty(colorbar_xlabel_data.String)
-    %-colorbar titleside-%
-    colorbar.titleside = 'right';
-    %-colorbar titlefont family-%:
-    colorbar.titlefont.family = matlab2plotlyfont(colorbar_xlabel_data.FontName);
-    %-colorbar titlefont color-%
-    col = 255*colorbar_xlabel_data.Color;
-    colorbar.titlefont.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
-    %-colorbar titlefont size-%
-    colorbar.titlefont.size = colorbar_xlabel_data.FontSize;
-elseif ~isempty(colorbar_ylabel_data.String)
-    %-colorbar titleside-%
-    colorbar.titleside = 'bottom';
-    %-colorbar titlefont family-%:
-    colorbar.titlefont.family = matlab2plotlyfont(colorbar_ylabel_data.FontName);
-    %-colorbar titlefont color-%
-    col = 255*colorbar_ylabel_data.Color;
-    colorbar.titlefont.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
-    %-colorbar titlefont size-%
-    colorbar.titlefont.size = colorbar_ylabel_data.FontSize;
-end
-
-%-REVERT UNITS-%
-set(colorbar_title,'Units',titleunits);
-set(colorbar_title,'FontUnits',titlefontunits);
-set(colorbar_ylabel,'Units',ylabelunits);
-set(colorbar_ylabel,'FontUnits',ylabelfontunits);
-
-if ~isHG2
-    set(colorbar_xlabel,'Units',xlabelunits);
-    set(colorbar_xlabel,'FontUnits',xlabelfontunits);
-end
-
-
-%-thicknessmode-%
-colorbar.thicknessmode = 'fraction';
-
-%-------------------------------------------------------------------------%
-
-%-thickness-%
-colorbar.thickness = colorbar_data.Position(3);
-
-%-------------------------------------------------------------------------%
-
-%-lenmode-%
-colorbar.lenmode = 'fraction';
-
-%-------------------------------------------------------------------------%
-
-%-length-%
-colorbar.len = colorbar_data.Position(4);
-
-%-------------------------------------------------------------------------%
-
-% orientation vertical check
-orientVert = colorbar.len > colorbar.thickness;
-
-%-------------------------------------------------------------------------%
-
-%-outline width-%
-linewidth = colorbar_data.LineWidth*obj.PlotlyDefaults.AxisLineIncreaseFactor;
-colorbar.outlinewidth = linewidth;
-
-%-------------------------------------------------------------------------%
-
-%-tickwidth-%
-colorbar.tickwidth = linewidth;
-
-%-------------------------------------------------------------------------%
-
-ticklength = min(obj.PlotlyDefaults.MaxTickLength,...
-    max(colorbar_data.TickLength(1)*colorbar_data.Position(3)*obj.layout.width,...
-    colorbar_data.TickLength(1)*colorbar_data.Position(4)*obj.layout.height));
-
-%-xaxis ticklen-%
-colorbar.ticklen = ticklength;
-
-%-------------------------------------------------------------------------%
-
-% check orientation for x/y properties
-
-if isHG2
-    col = [0 0 0];
-else
-    if orientVert
-        col = 255*colorbar_data.YColor;
+    if isHG2
+        colorbarTitleData = get(colorbarTitle);
+        colorbarYLabel = colorbarTitle;
+        colorbarYLabelData = get(colorbarTitle);
+        colorbarXLabelData.String = [];
     else
-        col = 255*colorbar_data.XColor;
+        colorbarTitleData = get(colorbarTitle);
+        colorbarXLabel = colorbarData.XLabel;
+        colorbarXLabelData = get(colorbarXLabel);
+        colorbarYLabel = colorbarData.YLabel;
+        colorbarYLabelData = get(colorbarYLabel);
     end
-end
 
-colorbar_col = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+    %-------------------------------------------------------------------------%
 
-%-outlinecolor-%
-colorbar.outlinecolor = colorbar_col;
+    %-STANDARDIZE UNITS FOR TITLE-%
+    titleunits = colorbarTitleData.Units;
+    titlefontunits = colorbarTitleData.FontUnits;
+    ylabelunits = colorbarYLabelData.Units;
+    ylabelfontunits = colorbarYLabelData.FontUnits;
+    set(colorbarTitle,'Units','data');
+    set(colorbarYLabel,'Units','data');
+    set(colorbarYLabel,'FontUnits','points');
+    if ~isHG2
+        xlabelunits = colorbarXLabelData.Units;
+        xlabelfontunits = colorbarXLabelData.FontUnits;
+        set(colorbarTitle,'FontUnits','points');
+        set(colorbarXLabel,'Units','data');
+        set(colorbarXLabel,'FontUnits','points');
+    end
 
-%-------------------------------------------------------------------------%
+    %-------------------------------------------------------------------------%
 
-%-tickcolor-%
-colorbar.tickcolor = colorbar_col;
+    %-colorbar title settings-%
+    isTitle = true;
 
-%-------------------------------------------------------------------------%
+    if ~isempty(colorbarTitleData.String)
+        titleString = colorbarTitleData.String;
+        titleInterpreter = colorbarTitleData.Interpreter;
 
-%-tickfont-%
-colorbar.tickfont.color = colorbar_col;
-
-%-------------------------------------------------------------------------%
-
-%-xaxis tick font size-%
-colorbar.tickfont.size = colorbar_data.FontSize;
-
-%-------------------------------------------------------------------------%
-
-%-xaxis tick font family-%
-colorbar.tickfont.family = matlab2plotlyfont(colorbar_data.FontName);
-
-%-------------------------------------------------------------------------%
-
-%-colorbar pad-%
-colorbar.xpad = obj.PlotlyDefaults.MarginPad;
-colorbar.ypad = obj.PlotlyDefaults.MarginPad;
-
-%-------------------------------------------------------------------------%
-
-% check orientation for x/y properties
-if ~isHG2
-    if orientVert
-        if isempty(colorbar_data.YTick)
-            %-show tick labels-%
-            colorbar.ticks = '';
-            colorbar.showticklabels = false;
+        if colorbarTitleData.Rotation == 90
+            titleSide = 'right';
         else
-            %-tick direction-%
-            switch colorbar_data.TickDir
+            titleSide = 'top';
+        end
+
+        titleFontSize = 1.20 * colorbarTitleData.FontSize;
+        titleFontColor = sprintf('rgb(%f,%f,%f)', 255*colorbarTitleData.Color);
+        titleFontFamily = matlab2plotlyfont(colorbarTitleData.FontName);
+
+    elseif ~isempty(colorbarXLabelData.String)
+        titleString = colorbarXLabelData.String;
+        titleInterpreter = colorbarXLabelData.Interpreter;
+
+        titleSide = 'right';
+        titleFontSize = 1.20 * colorbarXLabelData.FontSize;
+        titleFontColor = sprintf('rgb(%f,%f,%f)', 255*colorbarXLabelData.Color);
+        titleFontFamily = matlab2plotlyfont(colorbarXLabelData.FontName);
+
+    elseif ~isempty(colorbarYLabelData.String)
+        titleString = colorbarYLabelData.String;
+        titleInterpreter = colorbarYLabelData.Interpreter;
+
+        titleSide = 'bottom';
+        titleFontSize = 1.20 * colorbarYLabelData.FontSize;
+        titleFontColor = sprintf('rgb(%f,%f,%f)', 255*colorbarYLabelData.Color);
+        titleFontFamily = matlab2plotlyfont(colorbarYLabelData.FontName);
+
+    else
+        isTitle = false;
+    end
+
+    if isTitle
+        colorbar.title = parseString(titleString, titleInterpreter);
+        colorbar.titleside = titleSide;
+        colorbar.titlefont.size = titleFontSize;
+        colorbar.titlefont.color = titleFontColor;
+        colorbar.titlefont.family = titleFontFamily;
+    end
+
+    %-------------------------------------------------------------------------%
+
+    %-REVERT UNITS FOR TITLE-%
+    set(colorbarTitle,'Units',titleunits);
+    set(colorbarTitle,'FontUnits',titlefontunits);
+    set(colorbarYLabel,'Units',ylabelunits);
+    set(colorbarYLabel,'FontUnits',ylabelfontunits);
+
+    if ~isHG2
+        set(colorbarXLabel,'Units',xlabelunits);
+        set(colorbarXLabel,'FontUnits',xlabelfontunits);
+    end
+
+    %-------------------------------------------------------------------------%
+
+    %-tick labels-%
+    tickValues = colorbarData.Ticks;
+    tickLabels = colorbarData.TickLabels;
+    showTickLabels = true;
+
+    if isHG2
+        if isempty(tickValues)
+            showTickLabels = false;
+            colorbar.ticks = '';
+
+        elseif isempty(tickLabels)
+            colorbar.tickvals = tickValues;
+
+        else
+            colorbar.tickvals = tickValues;
+            colorbar.ticktext = tickLabels;
+        end
+
+        if showTickLabels
+            colorbar.showticklabels = showTickLabels;
+
+            switch colorbarData.AxisLocation
+                case 'in'
+                    colorbar.ticklabelposition = 'inside';
+                case 'out'
+                    colorbar.ticklabelposition = 'outside';
+            end
+
+            switch colorbarData.TickDirection
                 case 'in'
                     colorbar.ticks = 'inside';
                 case 'out'
                     colorbar.ticks = 'outside';
             end
-            
-            if strcmp(colorbar_data.YTickLabelMode,'auto')
-                %-autotick-%
-                colorbar.autotick = true;
-                %-numticks-%
-                colorbar.nticks = length(colorbar_data.YTick) + 1; %nticks = max ticks (so + 1)
-            else
-                %-show tick labels-%
-                if isempty(colorbar_data.YTickLabel)
-                    colorbar.showticklabels = false;
-                else
-                    %-autotick-%
-                    colorbar.autotick = false;
-                    %-tick0-%
-                    colorbar.tick0 = str2double(colorbar_data.YTickLabel(1,:));
-                    %-dtick-%
-                    colorbar.dtick = str2double(colorbar_data.YTickLabel(2,:)) - str2double(colorbar_data.YTickLabel(1,:));
-                end
-            end
-        end
-    else
-        if isempty(colorbar_data.XTick)
-            %-show tick labels-%
-            colorbar.ticks = '';
-            colorbar.showticklabels = false;
-        else
-            %-tick direction-%
-            switch colorbar_data.TickDir
-                case 'in'
-                    colorbar.ticks = 'inside';
-                case 'out'
-                    colorbar.ticks = 'outside';
-            end
-            
-            if strcmp(colorbar_data.XTickLabelMode,'auto')
-                %-autotick-%
-                colorbar.autotick = true;
-                %-numticks-%
-                colorbar.nticks = length(colorbar_data.XTick) + 1;
-            else
-                %-show tick labels-%
-                if isempty(colorbar_data.XTickLabel)
-                    colorbar.showticklabels = false;
-                else
-                    %-autotick-%
-                    colorbar.autotick = false;
-                    %-tick0-%
-                    colorbar.tick0 = str2double(colorbar_data.XTickLabel(1,:));
-                    %-dtick-%
-                    colorbar.dtick = str2double(colorbar_data.XTickLabel(2,:)) - str2double(colorbar_data.XTickLabel(1,:));
-                end
-            end
-        end
-    end
-end
-%-------------------------------------------------------------------------%
 
-if ~isHG2
+        end
+
+    else
+        colorbar = setTicksNotHG2(colorbar, colorbarData);
+    end
+
+    %-------------------------------------------------------------------------%
+
     %-colorbar bg-color-%
-    if ~ischar(colorbar_data.Color)
-        col = 255*colorbar_data.Color;
-    else
-        col = 255*figure_data.Color;
+    if ~isHG2
+        if ~ischar(colorbarData.Color)
+            bgColor = 255*colorbarData.Color;
+        else
+            bgColor = 255*figureData.Color;
+        end
+        
+        obj.layout.plot_bgcolor = sprintf('rgb(%f,%f,%f', bgColor);
     end
-    
-    obj.layout.plot_bgcolor = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+
+    %-------------------------------------------------------------------------%
+
+    %-ASSOCIATED DATA-%
+    if isfield(colorbarData.UserData,'dataref')
+        colorbarDataIndex = colorbarData.UserData.dataref;
+    else
+        colorbarDataIndex = findColorbarData(obj,colorbarIndex,colorbarData);
+    end
+
+    obj.data{colorbarDataIndex}.colorbar = colorbar;
+    obj.data{colorbarDataIndex}.showscale = true;
+
+    %-------------------------------------------------------------------------%
+
+    %-REVERT UNITS-%
+    set(obj.State.Colorbar(colorbarIndex).Handle,'Units',colorbarUnits);
+
+    %-------------------------------------------------------------------------%
 end
-%-------------------------------------------------------------------------%
 
 
-%--------------------------ASSOCIATED DATA--------------------------------%
+function colorbar = setTicksNotHG2(colorbar, colorbarData)
+    verticalOrientation = colorbar.len > colorbar.thickness;
 
-if isfield(colorbar_data.UserData,'dataref')
-    colorbarDataIndex = colorbar_data.UserData.dataref;
-else
-    colorbarDataIndex = findColorbarData(obj,colorbarIndex);
-end
-
-%-set colorbar-%
-obj.data{colorbarDataIndex}.colorbar = colorbar;
-
-%-show scale-%
-obj.data{colorbarDataIndex}.showscale = true;
-
-%-REVERT UNITS-%
-set(obj.State.Colorbar(colorbarIndex).Handle,'Units',colorbarunits);
-
+    if verticalOrientation
+        if isempty(colorbarData.YTick)
+            %-show tick labels-%
+            colorbar.ticks = '';
+            colorbar.showticklabels = false;
+        else
+            %-tick direction-%
+            switch colorbarData.TickDir
+                case 'in'
+                    colorbar.ticks = 'inside';
+                case 'out'
+                    colorbar.ticks = 'outside';
+            end
+            
+            if strcmp(colorbarData.YTickLabelMode,'auto')
+                %-autotick-%
+                colorbar.autotick = true;
+                %-numticks-%
+                colorbar.nticks = length(colorbarData.YTick) + 1; %nticks = max ticks (so + 1)
+            else
+                %-show tick labels-%
+                if isempty(colorbarData.YTickLabel)
+                    colorbar.showticklabels = false;
+                else
+                    %-autotick-%
+                    colorbar.autotick = false;
+                    %-tick0-%
+                    colorbar.tick0 = str2double(colorbarData.YTickLabel(1,:));
+                    %-dtick-%
+                    colorbar.dtick = str2double(colorbarData.YTickLabel(2,:)) - str2double(colorbarData.YTickLabel(1,:));
+                end
+            end
+        end
+    else
+        if isempty(colorbarData.XTick)
+            %-show tick labels-%
+            colorbar.ticks = '';
+            colorbar.showticklabels = false;
+        else
+            %-tick direction-%
+            switch colorbarData.TickDir
+                case 'in'
+                    colorbar.ticks = 'inside';
+                case 'out'
+                    colorbar.ticks = 'outside';
+            end
+            
+            if strcmp(colorbarData.XTickLabelMode,'auto')
+                %-autotick-%
+                colorbar.autotick = true;
+                %-numticks-%
+                colorbar.nticks = length(colorbarData.XTick) + 1;
+            else
+                %-show tick labels-%
+                if isempty(colorbarData.XTickLabel)
+                    colorbar.showticklabels = false;
+                else
+                    %-autotick-%
+                    colorbar.autotick = false;
+                    %-tick0-%
+                    colorbar.tick0 = str2double(colorbarData.XTickLabel(1,:));
+                    %-dtick-%
+                    colorbar.dtick = str2double(colorbarData.XTickLabel(2,:)) - str2double(colorbarData.XTickLabel(1,:));
+                end
+            end
+        end
+    end
 end
 

--- a/plotly/plotlyfig_aux/core/updateData.m
+++ b/plotly/plotlyfig_aux/core/updateData.m
@@ -26,12 +26,8 @@ try
         updateBar3(obj, dataIndex);
     elseif ismember('bar3h', lower(obj.PlotOptions.TreatAs))
         updateBar3h(obj, dataIndex); 
-    elseif ismember('surf', lower(obj.PlotOptions.TreatAs))
-        updateSurf(obj, dataIndex); 
     elseif ismember('fmesh', lower(obj.PlotOptions.TreatAs))
         updateFmesh(obj, dataIndex);
-    elseif ismember('mesh', lower(obj.PlotOptions.TreatAs))
-        updateMesh(obj, dataIndex); 
     elseif ismember('surfc', lower(obj.PlotOptions.TreatAs))
         updateSurfc(obj, dataIndex); 
     elseif ismember('meshc', lower(obj.PlotOptions.TreatAs))
@@ -97,7 +93,13 @@ try
             case 'rectangle'
                 updateRectangle(obj,dataIndex);
             case 'surface'
-                updateSurfaceplot(obj,dataIndex);
+                if ismember('surf', lower(obj.PlotOptions.TreatAs))
+                    updateSurf(obj, dataIndex); 
+                elseif ismember('mesh', lower(obj.PlotOptions.TreatAs))
+                    updateMesh(obj, dataIndex);
+                else
+                    updateSurfaceplot(obj,dataIndex);
+                end
             case {'functionsurface', 'parameterizedfunctionsurface'}
                 updateFunctionSurface(obj,dataIndex);
             case 'implicitfunctionsurface'

--- a/plotly/plotlyfig_aux/handlegraphics/updateContourgroup.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateContourgroup.m
@@ -239,7 +239,7 @@ end
 %-------------------------------------------------------------------------%
 
 %-contour showscale-%
-obj.data{contourIndex}.showscale = true;
+obj.data{contourIndex}.showscale = false;
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/handlegraphics/updateMesh.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateMesh.m
@@ -43,6 +43,10 @@ xData = meshData.XData;
 yData = meshData.YData;
 zData = meshData.ZData;
 
+if isvector(xData)
+    [xData, yData] = meshgrid(xData, yData);
+end
+
 %-reformat data to mesh-%
 xDataSurface = xData;
 yDataSurface = yData;

--- a/plotly/plotlyfig_aux/handlegraphics/updateSurf.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateSurf.m
@@ -43,6 +43,10 @@ xData = meshData.XData;
 yData = meshData.YData;
 zData = meshData.ZData;
 
+if isvector(xData)
+    [xData, yData] = meshgrid(xData, yData);
+end
+
 %-reformat data to mesh-%
 xDataSurface = xData;
 yDataSurface = yData;

--- a/plotly/plotlyfig_aux/helpers/findColorbarAxis.m
+++ b/plotly/plotlyfig_aux/helpers/findColorbarAxis.m
@@ -1,14 +1,23 @@
 function colorbarAxis = findColorbarAxis(obj,colorbarHandle)
-if isHG2    
-    colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'ColorbarPeerHandle'),colorbarHandle)),obj.State.Axis));
-    % If the above returns empty then we are on a more recent Matlab
-    % release where the appdata entry is called LayoutPeers
-    if isempty(colorbarAxisIndex)
-        colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'LayoutPeers'),colorbarHandle)),obj.State.Axis));
+
+    if isHG2    
+        colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'ColorbarPeerHandle'),colorbarHandle)),obj.State.Axis));
+
+        % If the above returns empty then we are on a more recent Matlab
+        % release where the appdata entry is called LayoutPeers
+        if isempty(colorbarAxisIndex)
+            colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'LayoutPeers'),colorbarHandle)),obj.State.Axis));
+        end
+
+    else
+        colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'LegendColorbarInnerList'),colorbarHandle) + ...
+            isequal(getappdata(x.Handle,'LegendColorbarOuterList'),colorbarHandle)),obj.State.Axis));
     end
-else
-    colorbarAxisIndex = find(arrayfun(@(x)(isequal(getappdata(x.Handle,'LegendColorbarInnerList'),colorbarHandle) + ...
-        isequal(getappdata(x.Handle,'LegendColorbarOuterList'),colorbarHandle)),obj.State.Axis));
-end
-colorbarAxis = obj.State.Axis(colorbarAxisIndex).Handle;
+
+    try
+        colorbarAxis = obj.State.Axis(colorbarAxisIndex).Handle;
+    catch
+        colorbarAxis = 1;
+    end
+
 end

--- a/plotly/plotlyfig_aux/helpers/findColorbarData.m
+++ b/plotly/plotlyfig_aux/helpers/findColorbarData.m
@@ -1,8 +1,39 @@
-function colorbarDataIndex = findColorbarData(obj,colorbarIndex)
-%locate index of data associated with colorbar
-colorbarDataIndex = find(arrayfun(@(x)eq(x.AssociatedAxis,obj.State.Colorbar(colorbarIndex).AssociatedAxis),obj.State.Plot),1);
-%if no matching data index found
-if isempty(colorbarDataIndex)
-    colorbarDataIndex = max(min(colorbarIndex,obj.State.Figure.NumPlots),1);
-end
+function colorbarDataIndex = findColorbarData(obj, colorbarIndex, colorbarData)
+
+    if nargin == 2
+
+        %locate index of data associated with colorbar
+        colorbarDataIndex = find( ...
+            arrayfun( @(x)eq(x.AssociatedAxis, ...
+                            obj.State.Colorbar(colorbarIndex).AssociatedAxis), ...
+                            obj.State.Plot ...
+                    ), ...
+            1 );
+
+        %if no matching data index found
+        if isempty(colorbarDataIndex)
+            colorbarDataIndex = max(min(colorbarIndex,obj.State.Figure.NumPlots),1);
+        end
+
+    elseif nargin == 3
+        c = 1; a = 1;
+        allAxesIndex = zeros(length(colorbarData.Parent.Children), 1);
+
+        for n = 1:length(colorbarData.Parent.Children)
+            if strcmp(colorbarData.Parent.Children(n).Type, 'colorbar')
+                allColorbarIndex(c) = n;
+                c = c + 1;
+            elseif strcmp(colorbarData.Parent.Children(n).Type, 'axes')
+                allAxesIndex(n) = a;
+                a = a + 1;
+            end
+        end
+
+        colorbarAxisIndex = allColorbarIndex(colorbarIndex) + 1;
+        colorbarAxisIndex = allAxesIndex(colorbarAxisIndex);
+        colorbarDataIndex = obj.State.Figure.NumAxes - colorbarAxisIndex + 1;
+
+        colorbarDataIndex = colorbarDataIndex;
+    end
+    
 end


### PR DESCRIPTION
This PR fix two main issues. In particular:

# ISSUE: Specify Axis Tick Values and Labels ([reference link](https://uk.mathworks.com/help/matlab/creating_plots/change-tick-marks-and-tick-labels-of-graph-1.html))

To specify Axis Tick Values and Labels there are two main functions/files involved, which are: `updateAxisData.m` and `extractAxisData.m`.

Previous versions of these two functions did not get the job done properly. For example, they failed in the following cases:

1. When it was necessary to rotate the Tick Labes
2. When necessary Change Tick Label Formatting
3. When we tried to make the Control Value in Exponent Label Using Ruler Objects

As a solution to this serious problem, I had to almost completely recode the `extractAxisData.m` function/file and make minor modifications to `updateAxisData.m`. Honestly, it seems to me that these files are more robust now. However, I will test them with the next cases that I will face.

I share below screenshots of results for all the examples in the code flow of the reference link.

## Change Tick Value Locations and Labels
Create x as 200 linearly spaced values between -10 and 10. Create y as the cosine of x. Plot the data.
```
x = linspace(-10,10,200);
y = cos(x);
plot(x,y)
```
<img width="1425" alt="Screen Shot 2021-10-06 at 9 18 03 AM" src="https://user-images.githubusercontent.com/56391490/136661770-f4d84299-d7a4-44d5-b37d-a8727e7398f6.png">

Change the tick value locations along the x-axis and y-axis. Specify the locations as a vector of increasing values. The values do not need to be evenly spaced.
Also, change the labels associated with each tick value along the x-axis. Specify the labels using a cell array of character vectors. To include special characters or Greek letters in the labels, use TeX markup, such as \pi for the π symbol.
```
xticks([-3*pi -2*pi -pi 0 pi 2*pi 3*pi])
xticklabels({'-3\pi','-2\pi','-\pi','0','\pi','2\pi','3\pi'})
yticks([-1 -0.8 -0.2 0 0.2 0.8 1])
```
<img width="1424" alt="Screen Shot 2021-10-06 at 6 34 16 PM" src="https://user-images.githubusercontent.com/56391490/136661798-695ac4b4-8326-42f3-9f6f-e2e02bd6e18d.png">

## Rotate Tick Labels
Create a scatter plot and rotate the tick labels along each axis. Specify the rotation as a scalar value. Positive values indicate counterclockwise rotation. Negative values indicate clockwise rotation.
```
x = 1000*rand(40,1);
y = rand(40,1);
scatter(x,y)
xtickangle(45)
ytickangle(90)
```
<img width="1457" alt="Screen Shot 2021-10-06 at 6 35 01 PM" src="https://user-images.githubusercontent.com/56391490/136661836-a819731d-f552-499d-83bc-504ca836452b.png">

## Change Tick Label Formatting
Create a stem chart and display the tick label values along the y-axis as US dollar values.
```
profit = [20 40 50 40 50 60 70 60 70 60 60 70 80 90];
stem(profit)
xlim([0 15])
ytickformat('usd')

```
<img width="1434" alt="Screen Shot 2021-10-06 at 6 35 33 PM" src="https://user-images.githubusercontent.com/56391490/136661902-63ae69d0-7f3b-4fcc-9ac6-c3d1c8997944.png">

For more control over the formatting, specify a custom format. For example, show one decimal value in the x-axis tick labels using '%.1f'. Display the y-axis tick labels as British Pounds using '\xA3%.2f'. The option \xA3 indicates the Unicode character for the Pound symbol. For more information on specifying a custom format, see the xtickformat function.
```
xtickformat('%.1f')
ytickformat('\xA3%.2f')
```
<img width="1454" alt="Screen Shot 2021-10-06 at 6 36 11 PM" src="https://user-images.githubusercontent.com/56391490/136661917-fe2cd587-fb98-4842-ba1d-21d8cfe1ffe3.png">

## Ruler Objects for Individual Axis Control
MATLAB creates a ruler object for each axis. Like all graphics objects, ruler objects have properties that you can view and modify. Ruler objects allow for more individual control over the formatting of the x-axis, y-axis, or z-axis. Access the ruler object associated with a particular axis through the XAxis, YAxis, or ZAxis property of the Axes object. The type of ruler depends on the type of data along the axis. For numeric data, MATLAB creates a NumericRuler object.
```
ax = gca;
ax.XAxis 
ans = 
  NumericRuler with properties:

             Limits: [0 15]
              Scale: 'linear'
           Exponent: 0
         TickValues: [0 5 10 15]
    TickLabelFormat: '%.1f'
```

## Control Value in Exponent Label Using Ruler Objects
Plot data with y values that range between -15,000 and 15,000. By default, the y-axis tick labels use exponential notation with an exponent value of 4 and a base of 10. Change the exponent value to 2. Set the Exponent property of the ruler object associated with the y-axis. Access the ruler object through the YAxis property of the Axes object. The exponent label and the tick labels change accordingly.
```
x = linspace(0,5,1000);
y = 100*exp(x).*sin(20*x);
plot(x,y)

ax = gca;
ax.YAxis.Exponent = 2;
```
<img width="1435" alt="Screen Shot 2021-10-06 at 6 38 00 PM" src="https://user-images.githubusercontent.com/56391490/136662012-3c247180-7a29-4d5b-8918-d6a469c00aee.png">

Change the exponent value to 0 so that the tick labels do not use exponential notation.
`ax.YAxis.Exponent = 0;`
<img width="1436" alt="Screen Shot 2021-10-06 at 6 38 32 PM" src="https://user-images.githubusercontent.com/56391490/136662028-86d787a5-7f89-44d5-bea7-892c32c27eea.png">

# ISSUE: colorbar ([reference link](https://uk.mathworks.com/help/matlab/ref/colorbar.html?searchHighlight=colorbars&s_tid=srchtitle))

The version prior to this update of `matlab_plotly` did not work properly with `colorbar`, it was very unstable and quite poor. This was mainly due to the `updateColorbar.m`, `findColorbarAxis.m` and `findColorbarData.m` functions/files.

The work for this new update was really challenging, because I had to adapt the code flow of `plotly_matlab` to properly parse the data structure that Matlab provides us with each chart, which was not an easy task. This new code update involved:

1. Fully recode the function/file `updateColorbar.m`,
2. Understand and recode the `findColorbarAxis.m` function/file to solve problems when we ran cases of colorbar with multiple Axes. These cases, in particular, threw errors in `findColorbarAxis.m` and prevented the corresponding Plotly chart from being created.
3. Understand and recode the function/file `findColorbarData.m` in favor of solving problems also related to cases of colorbar with multiple axes. In particular, the previous version of `findColorbarData.m` did not properly link the index of a certain colorbar with its corresponding chart when we had cases with multiple axes. It seems that it mixed the colorbars inappropriately between charts of the different Axes.

With this new update, we managed to solve many of the issues related to the colorbar. However, there are cases that cannot be solved.

**Among the solved cases we have:**

- Add Colorbars to Tiled Chart Layout
- Display Shared Colorbar in Tiled Chart Layout
- Specify Colorbar Ticks and Tick Labels
- Label Colorbar

**Among the cases that cannot be solved we have:**

- **Add Horizontal Colorbar to Graph.** This case, in particular, cannot be solved since plotly does not seem to allow displaying colorbar horizontally (please check this [link](https://github.com/plotly/plotly.js/issues/1244))
- **Reverse Colorbar Direction.** This case cannot be solved because the colorbar method that Plotly provides does not allow to create/customize the axis of the colorbar object.
- **Display Colorbar Ticks on Opposite Side.** This case is similar to the previous one. Plorly does not allow customizing the axis of the colorbar object. However, I added a conditional that allows to do something different for this case, but it is not the total solution (see the results below)

**NOTES:**

- When I talk about issues that cannot be solved, I mean that they cannot be solved using Plotly's colorbar functionality directly.
- However, I think they can be solved by creating an Axes and, in this, emulating the colorbar using a trace (I think in scatter).
- With this, we could customize all colorbar cases. This solution that I propose would be like doing a trick.
- However, doing this can take time and I prefer to ask first if it would be completely necessary right now. I say this, since this could be a future task while right now I better focus on other issues.

I share below screenshots of results for all the examples in the code flow of the previous link.

## Add Colorbar to Graph
Add a colorbar to a surface plot indicating the color scale.
```
surf(peaks)
colorbar
```
Status: Succesfully!
<img width="1488" alt="Screen Shot 2021-10-08 at 11 34 53 AM" src="https://user-images.githubusercontent.com/56391490/136662291-5c0c0de0-6aa8-47f7-be00-e827d5bcb438.png">

## Add Horizontal Colorbar to Graph
Add a horizontal colorbar below a plot by specifying the colorbar location as 'southoutside'.
```
contourf(peaks)
colorbar('southoutside')
f = fig2plotly(gcf, 'offline', 1);

```
Status: not fixed.
Notice how this new update to matlab_plotly positions the colorbar properly. However, Plotly displays the colorbar vertically. This is because Poltly's colorbar functionality does not allow colorbars to be displayed horizontally.
<img width="1471" alt="Screen Shot 2021-10-08 at 11 37 30 AM" src="https://user-images.githubusercontent.com/56391490/136662335-b9b1a3ba-33d1-4a1b-a1f8-29d0be6ad1b8.png">

## Reverse Colorbar Direction
Reverse the direction of values in a colorbar on a graph by setting the 'Direction' property of the colorbar to 'reverse'.
```
surf(peaks)
colorbar('Direction','reverse')
fig2plotly(gcf, 'offline', 1, 'TreatAs', 'surf');
```
Status: not fixed.
NOTE: As I said before, Plotly's colorbar functionality does not allow customizing the axis associated with the colorbar object. For example, it does not have a method like `range`, which allows us to flip the axes
<img width="1465" alt="Screen Shot 2021-10-08 at 11 43 38 AM" src="https://user-images.githubusercontent.com/56391490/136662351-413634b5-2c2d-4ce0-9d9c-7a92a89de7c6.png">

## Display Colorbar Ticks on Opposite Side
Display the colorbar tick marks and tick labels on the side of a colorbar facing the surface plot.
```
surf(peaks)
colorbar('AxisLocation','in')
fig2plotly(gcf, 'offline', 1, 'TreatAs', 'surf');
```
Status: not fixed at all
NOTE: similar to previous case. For example, Plotly's colorbar does not have a method like side, to properly position tick labels. It only has the `ticklabelposition` method, which allows us to place the ticklabels with respect to a fixed axis.
<img width="1430" alt="Screen Shot 2021-10-08 at 11 48 48 AM" src="https://user-images.githubusercontent.com/56391490/136662366-e8b44949-8b2e-4483-9071-baee863bdad1.png">

## Add Colorbars to Tiled Chart Layout
Starting in R2019b, you can display a tiling of plots using the tiledlayout and nexttile functions. Call the tiledlayout function to create a 2-by-1 tiled chart layout. Call the nexttile function to create the axes. Then display a surface plot in each axes with a colorbar.
```
tiledlayout(2,1)

% Top plot
nexttile 
surf(peaks)
colorbar

% Bottom plot
nexttile
mesh(peaks)
colorbar

fig2plotly(gcf, 'offline', 1, 'TreatAs', {'surf', 'mesh'});
```
Status: fixed!
NOTE: As I mentioned before, this case did not even generate a Plotly chart. Just the previous `matlab_plotly` code was breaking in the function `findColorbarAxis.m`. Now this works perfectly. Even later in the next chart I will test it with more complex multiple Axes cases.
<img width="1503" alt="Screen Shot 2021-10-08 at 11 53 49 AM" src="https://user-images.githubusercontent.com/56391490/136662407-320e2ae1-5b57-49b2-ba81-2010460a2354.png">

## More complex multiple axis cases.
Next we vary the colorbars for each axes by removing them from some and putting them on others. Notice how all the colorbars are perfectly linked to each axes.
<img width="1482" alt="Screen Shot 2021-10-08 at 11 57 23 AM" src="https://user-images.githubusercontent.com/56391490/136662442-8fe8eb9b-f298-4290-b773-303bd08ea768.png">
<img width="1480" alt="Screen Shot 2021-10-08 at 11 59 21 AM" src="https://user-images.githubusercontent.com/56391490/136662451-c52c8451-437b-47e4-9b60-f9858df4ace9.png">
<img width="1503" alt="Screen Shot 2021-10-08 at 11 59 56 AM" src="https://user-images.githubusercontent.com/56391490/136662456-c8781a00-2cdf-419a-a872-2c09e9c5fee1.png">
<img width="1511" alt="Screen Shot 2021-10-08 at 12 00 19 PM" src="https://user-images.githubusercontent.com/56391490/136662463-2441cb11-6d51-41a3-a82e-029ef3969017.png">

## Specify Colorbar Ticks and Tick Labels
Add a colorbar to a plot and specify the colorbar tick marks and tick labels. Specify the same number of tick labels as tick marks. If you do not specify enough tick labels, then the colorbar function repeats the labels.
```
contourf(peaks)
colorbar('Ticks',[-5,-2,1,4,7],...
         'TickLabels',{'Cold','Cool','Neutral','Warm','Hot'})
fig2plotly(gcf, 'offline', 1);
```
Status: fixed!
NOTE: The ticklabels of the colorbar appear perfectly. The previous version of `matlab_plotly` was not able to place the ticklabels, it only displayed the corresponding numbers of levels.
<img width="1442" alt="Screen Shot 2021-10-08 at 12 01 25 PM" src="https://user-images.githubusercontent.com/56391490/136662483-3157d919-295c-44ab-bce3-d8e73e1610a6.png">

## Label Colorbar
Add a text label along a colorbar.
```
surf(peaks)
c = colorbar;
c.Label.String = 'Elevation (ft in 1000s)';
fig2plotly(gcf, 'offline', 1, 'TreatAs', 'surf');
```
Status: fixed!
NOTE: The Label Colorbar is displayed perfectly positioned according to the MATLAB version. The previous version of matlab_plotly only placed the Label on the top of the colorbar horizontally
<img width="1434" alt="Screen Shot 2021-10-08 at 12 04 41 PM" src="https://user-images.githubusercontent.com/56391490/136662497-9757b35f-ff7c-498d-807b-90869f2d2dca.png">

## Delete Colorbar
Add a colorbar to a surface plot.
```
surf(peaks)
colorbar

```
Delete the colorbar from the surface plot.
```
colorbar('off')
fig2plotly(gcf, 'offline', 1, 'TreatAs', 'surf');
```
Status: it works perfectly!
<img width="1425" alt="Screen Shot 2021-10-08 at 12 08 58 PM" src="https://user-images.githubusercontent.com/56391490/136662516-ae35cc92-9f43-48b3-92e4-da7a71e80d52.png">

This PR fix isssue #394