### PR TITLE
fix issue related to add plotly themes (addtheme functionality)

### DIFF
--- a/plotly/addtheme.m
+++ b/plotly/addtheme.m
@@ -1,10 +1,27 @@
 function f = addtheme(f, theme)
     
-    % validate theme name
-    
-    S = dir('plotly/themes');
-    N = {S.name};
+    %-------------------------------------------------------------------------%
+
+    %-validate theme name-%
+
+    themePath = 'plotly/themes';
+    S = dir(themePath);
+
+    if isempty(S)
+        paths = split(path, ':');
         
+        for p = 1:length(paths)
+            if ~isempty(strfind(paths{p}, themePath))
+                themePath = paths{p};
+                break;
+            end
+        end
+
+        S = dir(themePath);
+    end
+
+    N = {S.name};
+
     if ~any(strcmp(N,strcat(theme, '.json'))) == 1
         ME = MException('MyComponent:noSuchVariable',...
             [strcat('\n<strong>', theme,...
@@ -13,10 +30,13 @@ function f = addtheme(f, theme)
             strrep(strrep([S.name], '...', ''), '.json', ' | ')]);
         throw(ME)
     end
+
+    %-------------------------------------------------------------------------%
         
-    % add theme to figure
+    %-add theme to figure-%
     
-    fname = strcat('plotly/themes/', theme, '.json');
+    fname = sprintf('%s/%s.json', themePath, theme);
+    % fname = strcat('plotly/themes/', theme, '.json');
     fid = fopen(fname); 
     raw = fread(fid,inf); 
     str = char(raw'); 
@@ -33,5 +53,7 @@ function f = addtheme(f, theme)
     if isfield(f.layout.template.layout, 'plot_bgcolor')
         disp(strcat('layout.plot_bgcolor:::',...
             f.layout.template.layout.plot_bgcolor))
-    end    
+    end
+
+    %-------------------------------------------------------------------------%
 end


### PR DESCRIPTION
This PR fix issues related to `addtheme`.

I share results bellow:

## `plotly_dark` theme
```
x = randn(10000,1);
h = histogram(x);
f = fig2plotly(gcf, 'open', false);

addtheme(f, 'plotly_dark');
response = plotlyoffline(f);

web(response, '-browser');
```
<img width="1516" alt="Screen Shot 2021-10-12 at 12 12 57 PM" src="https://user-images.githubusercontent.com/56391490/136993791-0c03f984-95da-4f9b-b7a7-fa5900be0996.png">

## `ggplot2` theme
```
addtheme(f, 'ggplot2');
response = plotlyoffline(f);

web(response, '-browser');
```
<img width="1446" alt="Screen Shot 2021-10-12 at 12 13 40 PM" src="https://user-images.githubusercontent.com/56391490/136994099-715de4cd-39f5-44d0-b985-ca4a1149d2f7.png">

## `seaborn` theme
```
addtheme(f, 'seaborn');
response = plotlyoffline(f);

web(response, '-browser');
```
<img width="1477" alt="Screen Shot 2021-10-12 at 12 14 28 PM" src="https://user-images.githubusercontent.com/56391490/136994195-13548992-0534-4fe6-989c-432470f6d93c.png">

## `plotly_white` theme
```
addtheme(f, 'plotly_white');
response = plotlyoffline(f);

web(response, '-browser');
```
<img width="1438" alt="Screen Shot 2021-10-12 at 12 15 50 PM" src="https://user-images.githubusercontent.com/56391490/136994306-13cb835c-3ac7-48b4-bf66-012510bfff1a.png">


