### PR TITLE
add tiledlayout annotations when tiledlayout functionality is used

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -579,6 +579,14 @@ classdef plotlyfig < handle
             obj.State.Figure.NumLegends = 0;
             obj.State.Figure.NumColorbars = 0;
             obj.State.Figure.NumTexts = 0;
+
+            % check if there is tiledlayout
+            try
+                tiledLayoutStruct = get(obj.State.Figure.Handle.Children);
+                isTiledLayout = strcmp(tiledLayoutStruct.Type, 'tiledlayout');
+            catch
+                isTiledLayout = false;
+            end
             
             % find axes of figure
             ax = findobj(obj.State.Figure.Handle,'Type','axes','-and',{'Tag','','-or','Tag','PlotMatrixBigAx','-or','Tag','PlotMatrixScatterAx', '-or','Tag','PlotMatrixHistAx'});
@@ -616,6 +624,7 @@ classdef plotlyfig < handle
             ax = temp_ax;
             %---------- checking the overlaping of the graphs ----------%
             
+            % update number of axes
             obj.State.Figure.NumAxes = length(ax);
             
             % update number of annotations (one title per axis)
@@ -712,7 +721,7 @@ classdef plotlyfig < handle
                 obj.State.Figure.NumTexts = obj.State.Figure.NumTexts + length(texts);
                 
             end
-            
+
             % find legends of figure
             if isHG2
                 legs = findobj(obj.State.Figure.Handle,'Type','Legend');
@@ -778,24 +787,13 @@ classdef plotlyfig < handle
                         end
                     end
                 catch
-                    % TODO to the future
-                    % disp('catch at line 647 in plotlyfig.m file')
+                    % TODO 
                 end
             end
             
             % update plots
             for n = 1:obj.State.Figure.NumPlots
                 updateData(obj,n);
-                
-                try
-                    if update_opac(length(ax)-n)
-                        % obj.data{1, n}.opacity = 0.9;
-                    end
-                catch
-                    % TODO to the future
-                    % disp('catch at line 664 in plotlyfig.m file')
-                end
-                
             end
             
             % update annotations
@@ -804,19 +802,27 @@ classdef plotlyfig < handle
                     if obj.PlotOptions.is_headmap_axis
                         updateHeatmapAnnotation(obj,n);
                         obj.PlotOptions.CleanFeedTitle = false;
+
                     elseif obj.PlotlyDefaults.isGeoaxis
-                        % TODO    
+                        % TODO
+
                     else
                         if ~obj.PlotlyDefaults.isTernary
                             updateAnnotation(obj,n);
+
                             if obj.State.Figure.NumAxes == 1
                                 obj.PlotOptions.CleanFeedTitle = false;
                             end
                         end
                     end
                 catch
-                    % TODO to the future
+                    % TODO
                 end
+            end
+
+            % update tiled layout annotations
+            if isTiledLayout
+                updateTiledLayoutAnnotation(obj, tiledLayoutStruct);
             end
             
             % update legends
@@ -826,6 +832,7 @@ classdef plotlyfig < handle
                         updateLegend(obj,n);
                     end
                 end
+
             else
                 updateLegendMultipleAxes(obj,1);
             end
@@ -834,6 +841,7 @@ classdef plotlyfig < handle
             for n = 1:obj.State.Figure.NumColorbars
                 if ~obj.PlotlyDefaults.isTernary
                     updateColorbar(obj,n);
+
                 else
                     updateTernaryColorbar(obj,n);
                 end

--- a/plotly/plotlyfig_aux/core/updateTiledLayoutAnnotation.m
+++ b/plotly/plotlyfig_aux/core/updateTiledLayoutAnnotation.m
@@ -1,0 +1,84 @@
+function obj = updateTiledLayoutAnnotation(obj, tiledLayoutData)
+
+    %-------------------------------------------------------------------------%
+
+    %-INITIALIZATIONS-%
+    anIndex = obj.State.Figure.NumTexts + 1;
+    titleStruct = get(tiledLayoutData.Title);
+
+    obj.layout.annotations{anIndex}.showarrow = false;
+    obj.layout.annotations{anIndex}.xref = 'paper';
+    obj.layout.annotations{anIndex}.yref = 'paper';
+    obj.layout.annotations{anIndex}.align = titleStruct.HorizontalAlignment;
+
+    %-------------------------------------------------------------------------%
+
+    %-anchors-%
+    obj.layout.annotations{anIndex}.xanchor = titleStruct.HorizontalAlignment;
+
+    switch titleStruct.VerticalAlignment
+        case {'top', 'cap'}
+            obj.layout.annotations{anIndex}.yanchor = 'top';
+        case 'middle'
+            obj.layout.annotations{anIndex}.yanchor = 'middle';
+        case {'baseline','bottom'}
+            obj.layout.annotations{anIndex}.yanchor = 'bottom';
+    end
+
+    %-------------------------------------------------------------------------%
+
+    %-text-%
+    titleString = titleStruct.String;
+    titleInterpreter = titleStruct.Interpreter;
+
+    if isempty(titleString)
+        titleTex = titleString;
+    else
+        titleTex = parseString(titleString, titleInterpreter);
+    end
+
+    obj.layout.annotations{anIndex}.text = titleTex;
+
+    %-------------------------------------------------------------------------%
+
+    %-text location-%
+    obj.layout.annotations{anIndex}.x = 0.5;
+    obj.layout.annotations{anIndex}.y = 0.95;
+
+    %-------------------------------------------------------------------------%
+
+    %-font properties-%
+    titleColor = sprintf('rgb(%f,%f,%f)', 255*titleStruct.Color);
+    titleSize = titleStruct.FontSize;
+    titleFamily = matlab2plotlyfont(titleStruct.FontName);
+
+    obj.layout.annotations{anIndex}.font.color = titleColor;
+    obj.layout.annotations{anIndex}.font.size = 1.2*titleSize;
+    obj.layout.annotations{anIndex}.font.family = titleFamily;
+
+    switch titleStruct.FontWeight
+        case {'bold','demi'}
+            titleString = sprintf('<b>%s</b>', titleString);
+            obj.layout.annotations{anIndex}.text = titleString;
+        otherwise
+    end
+
+    %-------------------------------------------------------------------------%
+
+    %-title angle-%
+    textAngle = titleStruct.Rotation;
+
+    if textAngle > 180
+        textAngle = textAngle - 360;
+    end
+
+    obj.layout.annotations{anIndex}.textangle = textAngle;
+
+    %-------------------------------------------------------------------------%
+
+    %-hide text (a workaround)-%
+    if strcmp(titleStruct.Visible,'off')
+        obj.layout.annotations{anIndex}.text = ' ';
+    end
+
+end


### PR DESCRIPTION
Previous `matlab_plotly` code did not take into account the main title when the `tiledlayout` functionality is used.

This PR have made the appropriate adjustments in the code to take this into account.

I share a screenshot with the result below.

```
t = tiledlayout(2,2);
title(t,"Trigonometric Functions")
x = linspace(0,30);

nexttile
plot(x,sin(x))
title("Sine")

nexttile
plot(x,cos(x))
title("Cosine")

nexttile
plot(x,tan(x))
title("Tangent")

nexttile
plot(x,sec(x))
title("Secant")

fig2plotly(gcf, 'offline', 1);
```

<img width="1473" alt="Screen Shot 2021-10-12 at 5 27 26 PM" src="https://user-images.githubusercontent.com/56391490/137032876-84e86aaa-d36d-4f1d-a4fa-38dc7c6c40f9.png">
