### PR TITLE
fix issue related to xscale when log scale is set

### DIFF
--- a/plotly/plotlyfig_aux/helpers/extractAxisData.m
+++ b/plotly/plotlyfig_aux/helpers/extractAxisData.m
@@ -122,7 +122,12 @@ function [axis, exponentFormat] = extractAxisData(obj,axisData,axisName)
         end
 
         if isnumeric(axisLim)
-            axis.range = axisLim;
+            if strcmp(axis.type, 'linear')
+                axis.range = axisLim;
+            elseif strcmp(axis.type, 'log')
+                axis.range = log10(axisLim);
+            end
+
         else
             axis.autorange = true;
         end
@@ -133,7 +138,6 @@ function [axis, exponentFormat] = extractAxisData(obj,axisData,axisName)
 
         %-set tick labels by using tick values and tick texts-%
         if ~isempty(tickValues) && ~isempty(tickLabels)
-
             axis.tickmode = 'array';
             axis.tickvals = tickValues;
             axis.ticktext = tickLabels;
@@ -142,7 +146,6 @@ function [axis, exponentFormat] = extractAxisData(obj,axisData,axisName)
 
         %-set tick labels by using only tick values-%
         elseif ~isempty(tickValues) && isempty(tickLabels)
-
             axis.tickmode = 'array';
             axis.tickvals = tickValues;
 


### PR DESCRIPTION
This PR fix a issue when log scale is set on axes. 

## Example code

```
gapminderDataFiveYear = readtable('https://raw.githubusercontent.com/plotly/datasets/master/gapminderDataFiveYear.csv');

year = 0;
if year == 0
    year = min(gapminderDataFiveYear.year);
end

YEAR = year;
rows = (gapminderDataFiveYear.year == YEAR);
subtab = gapminderDataFiveYear(rows,:);
scatter(subtab.gdpPercap, ...
    subtab.lifeExp, ...
    subtab.pop/100000, ...
    categorical(subtab.country), 'filled');

%set(gca,'FontSize',14);
%xlabel(gca, 'gdpPercap');
%ylabel(gca, 'lifeExp');  
set(gca,'xscale','log');

fig = fig2plotly(gcf, 'offline', true, 'open', false, 'Visible', false);
response = plotlyoffline(fig);

web(response, '-browser');
```

## Result:
<img width="849" alt="Screen Shot 2021-10-12 at 6 00 54 PM" src="https://user-images.githubusercontent.com/56391490/137036073-3f932542-51fc-4e32-9ecb-72a71956f8db.png">
