### PR TITLE
fix issue related to bar functionality

### DIFF
--- a/plotly/plotlyfig_aux/handlegraphics/updateBar.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateBar.m
@@ -1,163 +1,129 @@
 function obj = updateBar(obj,barIndex)
 
-% x: ...[DONE]
-% y: ...[DONE]
-% name: ...[DONE]
-% orientation: ...[DONE]
-% text: ...[NOT SUPPORTED IN MATLAB]
-% error_y: ...[HANDLED BY ERRORBAR]
-% error_x: ...[HANDLED BY ERRORBAR]
-% opacity: ...[DONE]
-% xaxis: ...[DONE]
-% yaxis: ...[DONE]
-% showlegend: ...[DONE]
-% stream: ...[HANDLED BY PLOTLY STREAM]
-% visible: ...[DONE]
-% type: ...[DONE]
-% r: ...[NA]
-% t: ...[NA]
-% textfont: ...[NA]
+    % x: ...[DONE]
+    % y: ...[DONE]
+    % name: ...[DONE]
+    % orientation: ...[DONE]
+    % text: ...[NOT SUPPORTED IN MATLAB]
+    % error_y: ...[HANDLED BY ERRORBAR]
+    % error_x: ...[HANDLED BY ERRORBAR]
+    % opacity: ...[DONE]
+    % xaxis: ...[DONE]
+    % yaxis: ...[DONE]
+    % showlegend: ...[DONE]
+    % stream: ...[HANDLED BY PLOTLY STREAM]
+    % visible: ...[DONE]
+    % type: ...[DONE]
+    % r: ...[NA]
+    % t: ...[NA]
+    % textfont: ...[NA]
 
-% MARKER:
-% color: ...DONE]
-% size: ...[NA]
-% symbol: ...[NA]
-% opacity: ...[NA]
-% sizeref: ...[NA]
-% sizemode: ...[NA]
-% colorscale: ...[NA]
-% cauto: ...[NA]
-% cmin: ...[NA]
-% cmax: ...[NA]
-% outliercolor: ...[NA]
-% maxdisplayed: ...[NA]
+    % MARKER:
+    % color: ...DONE]
+    % size: ...[NA]
+    % symbol: ...[NA]
+    % opacity: ...[NA]
+    % sizeref: ...[NA]
+    % sizemode: ...[NA]
+    % colorscale: ...[NA]
+    % cauto: ...[NA]
+    % cmin: ...[NA]
+    % cmax: ...[NA]
+    % outliercolor: ...[NA]
+    % maxdisplayed: ...[NA]
 
-% MARKER LINE:
-% color: ...[DONE]
-% width: ...[DONE]
-% dash: ...[NA]
-% opacity: ---[TODO]
-% shape: ...[NA]
-% smoothing: ...[NA]
-% outliercolor: ...[NA]
-% outlierwidth: ...[NA]
+    % MARKER LINE:
+    % color: ...[DONE]
+    % width: ...[DONE]
+    % dash: ...[NA]
+    % opacity: ---[TODO]
+    % shape: ...[NA]
+    % smoothing: ...[NA]
+    % outliercolor: ...[NA]
+    % outlierwidth: ...[NA]
 
-%-------------------------------------------------------------------------%
+    %-------------------------------------------------------------------------%
 
-%-AXIS INDEX-%
-axIndex = obj.getAxisIndex(obj.State.Plot(barIndex).AssociatedAxis);
+    %-AXIS INDEX-%
+    axIndex = obj.getAxisIndex(obj.State.Plot(barIndex).AssociatedAxis);
 
-%-BAR DATA STRUCTURE- %
-bar_data = obj.State.Plot(barIndex).Handle;
+    %-BAR DATA STRUCTURE- %
+    barData = obj.State.Plot(barIndex).Handle;
 
-%-CHECK FOR MULTIPLE AXES-%
-[xsource, ysource] = findSourceAxis(obj, axIndex);
+    %-CHECK FOR MULTIPLE AXES-%
+    [xSource, ySource] = findSourceAxis(obj, axIndex);
 
-%-AXIS DATA-%
-eval(['xaxis = obj.layout.xaxis' num2str(xsource) ';']);
-eval(['yaxis = obj.layout.yaxis' num2str(ysource) ';']);
+    %-------------------------------------------------------------------------%
 
-%-------------------------------------------------------------------------%
+    %-associate axis-%
+    obj.data{barIndex}.xaxis = sprintf('x%d', xSource);
+    obj.data{barIndex}.yaxis = sprintf('y%d', ySource);
 
-%-bar xaxis-%
-obj.data{barIndex}.xaxis = ['x' num2str(xsource)];
+    %-------------------------------------------------------------------------%
 
-%-------------------------------------------------------------------------%
+    %-set trace-%
+    obj.data{barIndex}.type = 'bar';
+    obj.data{barIndex}.name = barData.DisplayName;
+    obj.data{barIndex}.visible = strcmp(barData.Visible,'on');
 
-%-bar yaxis-%
-obj.data{barIndex}.yaxis = ['y' num2str(ysource)];
+    %-------------------------------------------------------------------------%
 
-%-------------------------------------------------------------------------%
-
-%-bar visible-%
-obj.data{barIndex}.visible = strcmp(bar_data.Visible,'on');
-
-%-------------------------------------------------------------------------%
-
-%-bar type-%
-obj.data{barIndex}.type = 'bar';
-
-%-------------------------------------------------------------------------%
-
-%-bar name-%
-obj.data{barIndex}.name = bar_data.DisplayName;
-
-%-------------------------------------------------------------------------%
-
-%-layout barmode-%
-switch bar_data.BarLayout
-    case 'grouped'
-        obj.layout.barmode = 'group';
-    case 'stacked'
-        obj.layout.barmode = 'relative';
-end
-
-%-------------------------------------------------------------------------%
-
-%-layout bargroupgap-%
-obj.layout.bargroupgap = 1-bar_data.BarWidth;
-
-%---------------------------------------------------------------------%
-
-%-layout bargap-%
-obj.layout.bargap = obj.PlotlyDefaults.Bargap;
-
-%-------------------------------------------------------------------------%
-
-%-bar orientation-%
-switch bar_data.Horizontal
-    
-    case 'off'
+    %-set plot data-%
+    switch barData.Horizontal
         
-        %-bar orientation-%
-        obj.data{barIndex}.orientation = 'v';
-        
-        %-bar x data-%
-        obj.data{barIndex}.x = bar_data.XData;
-        
-        %-bar y data-%
-        obj.data{barIndex}.y = bar_data.YData;
-        
-        
-    case 'on'
-        
-        %-bar orientation-%
-        obj.data{barIndex}.orientation = 'h';
-        
-        %-bar x data-%
-        obj.data{barIndex}.x = bar_data.YData;
-        
-        %-bar y data-%
-        obj.data{barIndex}.y = bar_data.XData;
-end
+        case 'off'
+            obj.data{barIndex}.orientation = 'v';
+            obj.data{barIndex}.x = barData.XData;
+            obj.data{barIndex}.y = barData.YData;
+            
+        case 'on'
+            obj.data{barIndex}.orientation = 'h';
+            obj.data{barIndex}.x = barData.YData;
+            obj.data{barIndex}.y = barData.XData;
+    end
 
-%---------------------------------------------------------------------%
+    %-------------------------------------------------------------------------%
 
-%-bar showlegend-%
-leg = get(bar_data.Annotation);
-legInfo = get(leg.LegendInformation);
+    %-trace settings-%
+    markerline = extractAreaLine(barData); 
 
-switch legInfo.IconDisplayStyle
-    case 'on'
-        showleg = true;
-    case 'off'
-        showleg = false;
-end
+    obj.data{barIndex}.marker = extractAreaFace(barData);
+    obj.data{barIndex}.marker.line = markerline; 
 
-obj.data{barIndex}.showlegend = showleg;
+    %-------------------------------------------------------------------------%
 
-%-------------------------------------------------------------------------%
+    %-layout settings-%
+    obj.layout.bargroupgap = 1-barData.BarWidth;
 
-%-bar marker-%
-obj.data{barIndex}.marker = extractAreaFace(bar_data);
+    try
+        obj.layout.bargap = obj.layout.bargap + 0.0625;
+    catch
+        obj.layout.bargap = 0.0625;
+    end
 
-%-------------------------------------------------------------------------%
+    switch barData.BarLayout
+        case 'grouped'
+            obj.layout.barmode = 'group';
+        case 'stacked'
+            obj.layout.barmode = 'relative';
+    end
 
-%-bar marker line-%
-markerline = extractAreaLine(bar_data); 
-obj.data{barIndex}.marker.line = markerline; 
+    %-------------------------------------------------------------------------%
 
-%-------------------------------------------------------------------------%
+    %-bar showlegend-%
+    leg = get(barData.Annotation);
+    legInfo = get(leg.LegendInformation);
+
+    switch legInfo.IconDisplayStyle
+        case 'on'
+            showleg = true;
+        case 'off'
+            showleg = false;
+    end
+
+    obj.data{barIndex}.showlegend = showleg;
+
+    %-------------------------------------------------------------------------%
 end
 
 


### PR DESCRIPTION
## Description of the issue
I'm trying a grouped bar plot:
```
clear all;close all;

x = categorical({'Apples', 'Oranges', 'Bananas'});
y = [2 2 3; 2 5 6; 2 8 9; 2 11 12];
bar(x,y)
shg

fig = fig2plotly(gcf, 'offline', true, 'open', false,'Visible',false);

response = plotlyoffline(fig);

web(response, '-browser');
```
When showing the image with `shg`  shows the correct plot, but `fig2plotly` shows clear axes.
I think there is some issue with categorical variables?
<img width="1222" alt="Screen Shot 2021-10-13 at 11 15 31 AM" src="https://user-images.githubusercontent.com/56391490/137162484-404c19e7-6992-4e17-846a-5e64e31a351c.png">

## Issue fixed
This PR fix the previous explained issue. So Using the example code we can get following 

<img width="1468" alt="Screen Shot 2021-10-13 at 10 56 09 AM" src="https://user-images.githubusercontent.com/56391490/137162706-7c47c503-8348-4c07-bb2a-ebbf4dd50150.png">

