### PR TITLE
adding slice functionality to matlab_plotly and fix issue #312

### DIFF
--- a/plotly/plotlyfig_aux/core/updateData.m
+++ b/plotly/plotlyfig_aux/core/updateData.m
@@ -107,6 +107,8 @@ try
                     updateSurf(obj, dataIndex); 
                 elseif ismember('mesh', lower(obj.PlotOptions.TreatAs))
                     updateMesh(obj, dataIndex);
+                elseif ismember('slice', lower(obj.PlotOptions.TreatAs))
+                    updateSlice(obj, dataIndex);
                 else
                     updateSurfaceplot(obj,dataIndex);
                 end

--- a/plotly/plotlyfig_aux/handlegraphics/updateSlice.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateSlice.m
@@ -1,0 +1,288 @@
+function obj = updateSlice(obj, dataIndex)
+
+    %-------------------------------------------------------------------------%
+
+    %-INITIALIZATIONS-%
+
+    axIndex = obj.getAxisIndex(obj.State.Plot(dataIndex).AssociatedAxis);
+    plotData = get(obj.State.Plot(dataIndex).Handle);
+    axisData = get(plotData.Parent);
+    figureData = get(obj.State.Figure.Handle);
+    [xSource, ~] = findSourceAxis(obj,axIndex);
+
+    %-update scene-%
+    updateScene(obj, dataIndex)
+
+    %-get trace data-%
+    xData = plotData.XData;
+    yData = plotData.YData;
+    zData = plotData.ZData;
+    cData = plotData.CData;
+
+    xDataSurf = zeros(2*(size(xData)-1));
+    yDataSurf = zeros(2*(size(xData)-1));
+    zDataSurf = zeros(2*(size(xData)-1));
+    cDataSurf = zeros(2*(size(xData)-1));
+
+    for n = 1:size(xData,2)-1
+        n2 = 2*(n-1) + 1;
+
+        for m = 1:size(xData,1)-1
+            m2 = 2*(m-1) + 1;
+
+            xDataSurf(m2:m2+1,n2:n2+1) = xData(m:m+1,n:n+1);
+            yDataSurf(m2:m2+1,n2:n2+1) = yData(m:m+1,n:n+1);
+            zDataSurf(m2:m2+1,n2:n2+1) = zData(m:m+1,n:n+1);
+
+            if strcmp(plotData.FaceColor, 'flat')
+                cDataSurf(m2:m2+1,n2:n2+1) = ones(2,2)*cData(m,n);
+            elseif strcmp(plotData.FaceColor, 'interp')
+                cDataSurf(m2:m2+1,n2:n2+1) = cData(m:m+1,n:n+1);
+            end
+
+        end
+    end
+
+    %-------------------------------------------------------------------------%
+
+    %-set trace-%
+    obj.data{dataIndex}.type = 'surface';
+    obj.data{dataIndex}.name = plotData.DisplayName;
+    obj.data{dataIndex}.visible = strcmp(plotData.Visible,'on');
+    obj.data{dataIndex}.scene = sprintf('scene%d', xSource);
+    obj.data{dataIndex}.showscale = false;
+    obj.data{dataIndex}.surfacecolor = cDataSurf;
+    
+    %-------------------------------------------------------------------------%
+
+    %-set trace data-%
+    obj.data{dataIndex}.x = xDataSurf;
+    obj.data{dataIndex}.y = yDataSurf;
+    obj.data{dataIndex}.z = zDataSurf;
+
+    %-------------------------------------------------------------------------%
+
+    %-update face color-%
+    updateSurfaceFaceColor(obj, dataIndex, cDataSurf);
+
+    %-update edge color-%
+    if isnumeric(plotData.EdgeColor)
+        updateSurfaceEdgeColor(obj, dataIndex);
+    end
+    
+    %-------------------------------------------------------------------------%
+end
+
+function updateScene(obj, dataIndex)
+
+    %-------------------------------------------------------------------------%
+
+    %-INITIALIZATIONS-%
+    axIndex = obj.getAxisIndex(obj.State.Plot(dataIndex).AssociatedAxis);
+    plotData = get(obj.State.Plot(dataIndex).Handle);
+    axisData = get(plotData.Parent);
+    [xSource, ~] = findSourceAxis(obj, axIndex);
+    scene = eval( sprintf('obj.layout.scene%d', xSource) );
+
+    aspectRatio = axisData.PlotBoxAspectRatio;
+    cameraPosition = axisData.CameraPosition;
+    dataAspectRatio = axisData.DataAspectRatio;
+    cameraUpVector = axisData.CameraUpVector;
+    cameraEye = cameraPosition./dataAspectRatio;
+    normFac = 0.625*abs(min(cameraEye));
+
+    %-------------------------------------------------------------------------%
+
+    %-aspect ratio-%
+    scene.aspectratio.x = 1.15*aspectRatio(1);
+    scene.aspectratio.y = 1.0*aspectRatio(2);
+    scene.aspectratio.z = 0.9*aspectRatio(3);
+
+    %-camera eye-%
+    scene.camera.eye.x = cameraEye(1) / normFac;
+    scene.camera.eye.y = cameraEye(2) / normFac;
+    scene.camera.eye.z = cameraEye(3) / normFac;
+
+    %-camera up-%
+    scene.camera.up.x = cameraUpVector(1); 
+    scene.camera.up.y = cameraUpVector(2);
+    scene.camera.up.z = cameraUpVector(3);
+
+    %-camera projection-%
+    % scene.camera.projection.type = axisData.Projection;
+
+    %-------------------------------------------------------------------------%
+
+    %-scene axis configuration-%
+    scene.xaxis.range = axisData.XLim;
+    scene.yaxis.range = axisData.YLim;
+    scene.zaxis.range = axisData.ZLim;
+
+    scene.xaxis.zeroline = false;
+    scene.yaxis.zeroline = false;
+    scene.zaxis.zeroline = false;
+
+    scene.xaxis.showline = true;
+    scene.yaxis.showline = true;
+    scene.zaxis.showline = true;
+
+    scene.xaxis.ticklabelposition = 'outside';
+    scene.yaxis.ticklabelposition = 'outside';
+    scene.zaxis.ticklabelposition = 'outside';
+
+    scene.xaxis.title = axisData.XLabel.String;
+    scene.yaxis.title = axisData.YLabel.String;
+    scene.zaxis.title = axisData.ZLabel.String;
+
+    %-tick labels-%
+    scene.xaxis.tickvals = axisData.XTick;
+    scene.xaxis.ticktext = axisData.XTickLabel;
+    scene.yaxis.tickvals = axisData.YTick;
+    scene.yaxis.ticktext = axisData.YTickLabel;
+    scene.zaxis.tickvals = axisData.ZTick;
+    scene.zaxis.ticktext = axisData.ZTickLabel;
+
+    scene.xaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.yaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.zaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.xaxis.tickfont.size = axisData.FontSize;
+    scene.yaxis.tickfont.size = axisData.FontSize;
+    scene.zaxis.tickfont.size = axisData.FontSize;
+    scene.xaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+    scene.yaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+    scene.zaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+
+    %-grid-%
+    if strcmp(axisData.XGrid, 'off'), scene.xaxis.showgrid = false; end
+    if strcmp(axisData.YGrid, 'off'), scene.yaxis.showgrid = false; end
+    if strcmp(axisData.ZGrid, 'off'), scene.zaxis.showgrid = false; end
+
+    %-------------------------------------------------------------------------%
+
+    %-SET SCENE TO LAYOUT-%
+    obj.layout = setfield(obj.layout, sprintf('scene%d', xSource), scene);
+
+    %-------------------------------------------------------------------------%
+end
+
+function updateSurfaceEdgeColor(obj, dataIndex)
+
+    %-------------------------------------------------------------------------%
+
+    %-INITIALIZATIONS-%
+
+    axIndex = obj.getAxisIndex(obj.State.Plot(dataIndex).AssociatedAxis);
+    plotData = get(obj.State.Plot(dataIndex).Handle);
+    axisData = get(plotData.Parent);
+
+    xData = plotData.XData;
+    yData = plotData.YData;
+    zData = plotData.ZData;
+    cData = plotData.CData;
+    edgeColor = plotData.EdgeColor;
+    cData = plotData.CData;
+    cLim = axisData.CLim;
+    colorMap = axisData.Colormap;
+
+    xConst = ( xData(:) - min(xData(:)) ) <= 1e-6;
+    yConst = ( yData(:) - min(yData(:)) ) <= 1e-6;
+
+    %-------------------------------------------------------------------------%
+
+    %-edge lines in x direction-%
+    xContourSize = mean(diff(xData(1,:)));
+    xContourStard = min(xData(1,:));
+    xContourEnd = max(xData(1,:));    
+
+    obj.data{dataIndex}.contours.x.show = true;
+    obj.data{dataIndex}.contours.x.start = xContourStard;
+    obj.data{dataIndex}.contours.x.end = xContourEnd;
+    obj.data{dataIndex}.contours.x.size = xContourSize;
+
+    %-edge lines in y direction-%
+    yContourSize = mean(diff(yData(:,1)));
+    yContourStard = min(yData(:,1));
+    yContourEnd = max(yData(:,1));
+    
+    obj.data{dataIndex}.contours.y.show = true;
+    obj.data{dataIndex}.contours.y.start = yContourStard;
+    obj.data{dataIndex}.contours.y.end = yContourEnd;
+    obj.data{dataIndex}.contours.y.size = yContourSize;
+
+    %-edge lines in z direction-%
+
+    if all(xConst) || all(yConst)
+        zContourSize = mean(diff(zData(1,:)));
+        zContourStard = min(zData(1,:));
+        zContourEnd = max(zData(1,:));
+
+        obj.data{dataIndex}.contours.z.show = true;
+        obj.data{dataIndex}.contours.z.start = zContourStard;
+        obj.data{dataIndex}.contours.z.end = zContourEnd;
+        obj.data{dataIndex}.contours.z.size = zContourSize;
+    end
+
+    %-------------------------------------------------------------------------%
+
+    %-coloring-%
+    numColor = 255 * edgeColor;
+    stringColor = getStringColor(numColor);
+
+    obj.data{dataIndex}.contours.x.color = stringColor;
+    obj.data{dataIndex}.contours.y.color = stringColor;
+    obj.data{dataIndex}.contours.z.color = stringColor;
+
+    %-------------------------------------------------------------------------%
+end
+
+function updateSurfaceFaceColor(obj, dataIndex, surfaceColor)
+
+    %-------------------------------------------------------------------------%
+
+    %-INITIALIZATIONS-%
+
+    axIndex = obj.getAxisIndex(obj.State.Plot(dataIndex).AssociatedAxis);
+    plotData = get(obj.State.Plot(dataIndex).Handle);
+    axisData = get(plotData.Parent);
+
+    faceColor = plotData.FaceColor;
+    cLim = axisData.CLim;
+    colorMap = axisData.Colormap;
+
+    obj.data{dataIndex}.cauto = false;
+    obj.data{dataIndex}.autocolorscale = false;
+    
+    %-------------------------------------------------------------------------%
+
+    if isnumeric(faceColor)
+        numColor = 255 * faceColor;
+        stringColor = getStringColor(numColor);
+
+        colorScale{1} = {0, stringColor};
+        colorScale{2} = {1, stringColor};
+        obj.data{dataIndex}.colorscale = colorScale;
+
+    elseif ismember(faceColor, {'flat', 'interp'})
+
+        nColors = size(colorMap, 1);
+            
+        for c = 1:nColors
+            stringColor = getStringColor(255*colorMap(c,:));
+            colorScale{c} = {(c-1)/(nColors-1), stringColor};
+        end
+
+        obj.data{dataIndex}.cmin = cLim(1);
+        obj.data{dataIndex}.cmax = cLim(2);
+
+    end
+
+    obj.data{dataIndex}.surfacecolor = surfaceColor;
+    obj.data{dataIndex}.colorscale = colorScale;
+
+    %-------------------------------------------------------------------------%
+end
+
+function stringColor = getStringColor(numColor)
+    
+    stringColor = sprintf('rgb(%f,%f,%f)', numColor);
+end


### PR DESCRIPTION
In favor of fixing all pending issues, this time I was working with [issue #312](https://github.com/plotly/plotly_matlab/issues/312). This issue is related to the MATLAB `slice` functionality. When trying to replicate the charts of the `slice` functionality, the previous `matlab_plotly` code resulted in bad plotly charts. This is basically because the `slice` functionality was not implemented in `matlab_plotly`. With this PR I have added this functionality by coding all the related code from scratch.

Specifically, I have fully coded the `updateSlice.m` file with which the charts of the slice functionality are now properly created with plotly.

It is important to note that to use the `slice` functionality, it is necessary to set the optional parameter `'TreatAs'` to `'slice'`.

Below I share examples of use taken from the MATLAB page

## Volume Data Along Slices

Show volumetric data along slice planes that are orthogonal to each axis.
Create slice planes through the volume defined by v=xe−x2−y2−z2, where x, y, and z range from [-2,2]. Create slice planes orthogonal to the x-axis at the values -1.2, 0.8, and 2 and orthogonal to the z-axis at the value 0. Do not create any slice planes that are orthogonal to the y-axis by specifying an empty array.

```
[X,Y,Z] = meshgrid(-2:.2:2);
V = X.*exp(-X.^2-Y.^2-Z.^2);

xslice = [-1.2,0.8,2];   
yslice = [];
zslice = 0;
slice(X,Y,Z,V,xslice,yslice,zslice)

fig2plotly(gcf, 'offline', 1, 'treatAs', 'slice');
```
<img width="1533" alt="Screen Shot 2021-10-20 at 8 26 10 PM" src="https://user-images.githubusercontent.com/56391490/138191367-c1e60303-c856-4361-a2b6-1817def4f509.png">

## Volume Data Along Surface

Show volumetric data along a nonplanar slice. Define the surface where you want to show the volumetric data.
Create volume array V as the volume defined by v=xe−x2−y2−z2, where x, y, and z range from [-5,5]. Then, show a slice of the volume data along the surface defined by z=x2−y2.

```
[X,Y,Z] = meshgrid(-5:0.2:5);
V = X.*exp(-X.^2-Y.^2-Z.^2);

[xsurf,ysurf] = meshgrid(-2:0.2:2);
zsurf = xsurf.^2-ysurf.^2;
slice(X,Y,Z,V,xsurf,ysurf,zsurf)

fig2plotly(gcf, 'offline', 1, 'treatAs', 'slice');
```

<img width="1532" alt="Screen Shot 2021-10-20 at 8 28 27 PM" src="https://user-images.githubusercontent.com/56391490/138191425-71987b53-476c-4897-b0a3-194c4e6cb06e.png">

## Specify Interpolation Method

Create a slice plane through volumetric data. Specify the interpolation method for the data values.
Create a slice plane orthogonal to the x-axis at the value 0.8. Since the volume data is not defined for x values of 0.8, the slice function interpolates the nearby values. To use the nearest data point value, specify the interpolation method as 'nearest'.

```
[X,Y,Z] = meshgrid(-2:2);
V = X.*exp(-X.^2-Y.^2-Z.^2);
xslice = 0.8;   
yslice = [];
zslice = [];
slice(X,Y,Z,V,xslice,yslice,zslice,'nearest')
```

<img width="1541" alt="Screen Shot 2021-10-20 at 8 29 15 PM" src="https://user-images.githubusercontent.com/56391490/138191467-ad713757-ecf0-490d-ba7e-91d3a1193149.png">

## EXTRA:
Previous example use FaceColor = 'flat' to coloring the slice surface chart. But the updated code works for FaceColor = 'interp' as well.

```
[X,Y,Z] = meshgrid(-2:2);
V = X.*exp(-X.^2-Y.^2-Z.^2);
xslice = 0.8;   
yslice = [];
zslice = [];
s = slice(X,Y,Z,V,xslice,yslice,zslice,'nearest');

s(1).FaceColor = 'interp';

fig2plotly(gcf, 'offline', 1, 'treatAs', 'slice');

```

Bellow the result. Please note how the face color is now corresponding to interp

<img width="1542" alt="Screen Shot 2021-10-20 at 8 29 34 PM" src="https://user-images.githubusercontent.com/56391490/138191510-f29064ac-66c6-498d-822c-e56a58b3a1ef.png">

