### PR TITLE
fix issue in plotlyfig.m when using plotly function

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -390,7 +390,11 @@ classdef plotlyfig < handle
             
             % validate data fields
             for d = 1:length(obj.data)
-                obj.stripkeys(obj.data{d}, obj.data{d}.type, {'style','plot_info'});
+                try
+                    obj.stripkeys(obj.data{d}, obj.data{d}.type, {'style','plot_info'});
+                catch
+                    % TODO
+                end
             end
             
             % validate layout fields
@@ -1068,7 +1072,7 @@ classdef plotlyfig < handle
     methods (Access=private)
         %----STRIP THE FIELDS OF A SPECIFIED KEY-----%
         function stripped = stripkeys(obj, fields, fieldname, key)
-            
+
             %plorlt reference
             pr = obj.PlotlyReference;
             


### PR DESCRIPTION
This PR fix one issue when using following code

```
url = 'https://raw.githubusercontent.com/plotly/datasets/master/MATLAB/Z.csv';

Z = readmatrix(url);

data = {...
  struct(...
    'z', Z, ...
    'colorscale', {
        {0.0, 'rgb(165,0,38)'},...
        {0.111, 'rgb(215,48,39)'},...
        {0.222, 'rgb(244,109,67)'},...
        {0.333, 'rgb(253,174,97)'},...
        {0.444, 'rgb(254,224,144)'},...
        {0.555, 'rgb(224,243,248)'},...
        {0.667, 'rgb(171,217,233)'},...
        {0.778, 'rgb(116,173,209)'},...
        {0.889, 'rgb(69,117,180)'},...
        {1.0, 'rgb(49,54,149)'} },...
    'type', 'heatmap')...
};

plotly(data);
```

<img width="874" alt="Screen Shot 2021-10-20 at 9 21 52 PM" src="https://user-images.githubusercontent.com/56391490/138195595-3586700e-5ad1-4b50-a2fe-17e712a4b5af.png">


