### PR TITLE
fix issue #424

### DIFF
--- a/plotly/plotlyfig_aux/handlegraphics/updateAlternativeBoxplot.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateAlternativeBoxplot.m
@@ -1,0 +1,114 @@
+function obj = updateAlternativeBoxplot(obj, dataIndex)
+
+	%-------------------------------------------------------------------------%
+
+	%-INITIALIZATIONS-%
+
+	axIndex = obj.getAxisIndex(obj.State.Plot(dataIndex).AssociatedAxis);
+	plotStructure = get(obj.State.Plot(dataIndex).Handle);
+	plotData = plotStructure.Children;
+
+	nTraces = length(plotData);
+	traceIndex = dataIndex;
+
+	%-------------------------------------------------------------------------%
+
+	%-update traces-%
+
+	for t = 1:nTraces
+	
+		if t ~= 1
+			obj.PlotOptions.nPlots = obj.PlotOptions.nPlots + 1;
+			traceIndex = obj.PlotOptions.nPlots;
+		end
+
+		updateBoxplotLine(obj, axIndex, plotData(t), traceIndex);
+	end
+
+	%-------------------------------------------------------------------------%
+end
+
+function updateBoxplotLine(obj, axIndex, plotData, traceIndex)
+
+	%-------------------------------------------------------------------------%
+
+	%-INITIALIZATIONS-%
+
+	%-get axis info-%
+	[xSource, ySource] = findSourceAxis(obj, axIndex);
+
+	%-get trade data-%
+	xData = plotData.XData;
+	yData = plotData.YData;
+
+	if isduration(xData) || isdatetime(xData), xData = datenum(xData); end
+    if isduration(yData) || isdatetime(yData), yData = datenum(yData); end
+
+    if length(xData) < 2, xData = ones(1,2)*xData; end
+    if length(yData) < 2, yData = ones(1,2)*yData; end
+
+    %-------------------------------------------------------------------------%
+
+    %-set trace-%
+    obj.data{traceIndex}.type = 'scatter';
+    obj.data{traceIndex}.mode = getScatterMode(plotData);
+    obj.data{traceIndex}.visible = strcmp(plotData.Visible,'on');
+    obj.data{traceIndex}.name = plotData.DisplayName;
+    obj.data{traceIndex}.xaxis = sprintf('x%d', xSource);
+    obj.data{traceIndex}.yaxis = sprintf('y%d', ySource);
+
+    %-------------------------------------------------------------------------%
+
+    %-set trace data-%
+    obj.data{traceIndex}.x = xData;
+    obj.data{traceIndex}.y = yData;
+
+    %-------------------------------------------------------------------------%
+
+    %-set marker properties-%
+    obj.data{traceIndex}.marker = extractLineMarker(plotData);
+
+    %-set line properties-%
+    obj.data{traceIndex}.line = extractLineLine(plotData);
+
+    %-------------------------------------------------------------------------%
+
+    %-legend-%
+    leg = get(plotData.Annotation);
+    legInfo = get(leg.LegendInformation);
+
+    switch legInfo.IconDisplayStyle
+        case 'on'
+            showLeg = true;
+        case 'off'
+            showLeg = false;
+    end
+
+    obj.data{traceIndex}.showlegend = showLeg;
+
+    if isempty(obj.data{traceIndex}.name)
+        obj.data{traceIndex}.showlegend = false;
+    end
+
+    %-------------------------------------------------------------------------%
+end
+
+function scatterMode = getScatterMode(plotData)
+
+	marker = plotData.Marker;
+	lineStyle = plotData.LineStyle;
+
+	if ~strcmpi('none', marker) && ~strcmpi('none', lineStyle)
+        scatterMode = 'lines+markers';
+
+    elseif ~strcmpi('none', marker)
+        scatterMode = 'markers';
+
+    elseif ~strcmpi('none', lineStyle)
+        scatterMode = 'lines';
+
+    else
+        scatterMode = 'none';
+
+    end
+end

--- a/plotly/plotlyfig_aux/handlegraphics/updateBoxplot.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateBoxplot.m
@@ -60,6 +60,7 @@ if isCompact
     bpnum = length(box_child)/bpcompnum;
     % check for assumed box structure
     if mod(length(box_child), bpcompnum)~=0
+        updateAlternativeBoxplot(obj, boxIndex);
         return
     end
 else
@@ -67,6 +68,7 @@ else
     bpnum = length(box_child)/bpcompnum;
     % check for assumed box structure
     if mod(length(box_child),bpcompnum)~=0
+        updateAlternativeBoxplot(obj, boxIndex);
         return
     end
 end


### PR DESCRIPTION
This PR fix the issues in [issue #424 post](https://github.com/plotly/plotly_matlab/issues/424).

## First case

```
data1 = normrnd(5,1,100,1);
data2 = normrnd(6,1,100,1);

fig = figure;
boxplot([data1,data2])

fig2plotly(fig);
```

<img width="1557" alt="Screen Shot 2021-10-22 at 7 52 39 PM" src="https://user-images.githubusercontent.com/56391490/138534298-86ba07b7-6ec2-477d-9b5e-ad35703e6cd2.png">

## Second case

```
x = {'day 1' 'day 1' 'day 1' 'day 1' 'day 1' 'day 1' ...
     'day 2' 'day 2' 'day 2' 'day 2' 'day 2' 'day 2'};

trace1 = struct(...
  'y', [0.2, 0.2, 0.6, 1.0, 0.5, 0.4, 0.2, 0.7, 0.9, 0.1, 0.5, 0.3], ...
  'x', x, ...
  'name', 'kale', ...
  'marker', struct('color', '#3D9970'), ...
  'type', 'box');

trace2 = struct(...
  'y', [0.6, 0.7, 0.3, 0.6, 0.0, 0.5, 0.7, 0.9, 0.5, 0.8, 0.7, 0.2], ...
  'x', x, ...
  'name', 'radishes', ...
  'marker', struct('color', '#FF4136'), ...
  'type', 'box');

trace3 = struct(...
  'y', [0.1, 0.3, 0.1, 0.9, 0.6, 0.6, 0.9, 1.0, 0.3, 0.6, 0.8, 0.5], ...
  'x', x, ...
  'name', 'carrots', ...
  'marker', struct('color', '#FF851B'), ...
  'type', 'box');

data = {trace1, trace2, trace3};

layout = struct(...
    'yaxis', struct(...
      'title', 'normalized moisture', ...
      'zeroline', false), ...
    'boxmode', 'group');

plotly(data, struct('layout', layout));
```

<img width="851" alt="Screen Shot 2021-10-22 at 7 55 24 PM" src="https://user-images.githubusercontent.com/56391490/138534325-9d6b4e51-8b13-470a-9679-efef9b3eff20.png">


