### PR TITLE
fix issue #453

### DIFF
--- a/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateQuiver.m
@@ -145,18 +145,24 @@ function updateScene(obj, dataIndex)
     [xSource, ~] = findSourceAxis(obj, axIndex);
     scene = eval( sprintf('obj.layout.scene%d', xSource) );
 
+    position = axisData.Position;
     aspectRatio = axisData.PlotBoxAspectRatio;
     cameraPosition = axisData.CameraPosition;
     dataAspectRatio = axisData.DataAspectRatio;
     cameraUpVector = axisData.CameraUpVector;
     cameraEye = cameraPosition./dataAspectRatio;
-
+    normFac = abs(min(cameraEye));
+    
     try
-        normFac = 0.42 - 0.105 * (size(axisData.Layout.TileSpan, 2) - 1);
-        normFac = normFac * abs(min(cameraEye));
+        fac = size(axisData.Layout.TileSpan, 2);
     catch
-        normFac = 0.42 * abs(min(cameraEye));
+        fac = 1;
     end
+
+    r1 = range([ 1, prod(aspectRatio([1,2])) ]);
+    r2 = range([ 1, prod(aspectRatio([1,3])) ]);
+    r3 = range([ 1, prod(aspectRatio([2,3])) ]);
+    r = max([r1, r2, r3]);
 
     %-------------------------------------------------------------------------%
 
@@ -166,9 +172,9 @@ function updateScene(obj, dataIndex)
     scene.aspectratio.z = 1.0*aspectRatio(3);
 
     %-camera eye-%
-    scene.camera.eye.x = cameraEye(1) / normFac;
-    scene.camera.eye.y = cameraEye(2) / normFac;
-    scene.camera.eye.z = cameraEye(3) / normFac;
+    scene.camera.eye.x = cameraEye(1) / normFac * (1.4 + r * fac);
+    scene.camera.eye.y = cameraEye(2) / normFac * (1.4 + r * fac);
+    scene.camera.eye.z = cameraEye(3) / normFac * (1.4 + r * fac);
 
     %-camera up-%
     scene.camera.up.x = cameraUpVector(1); 
@@ -422,7 +428,8 @@ end
 
 
 function scaleFactor = getScaleFactor(xData, uData, nSteps)
-    xStep = max( abs(diff( mean(xData, 1) )) );
+
+    xStep = max( abs(diff( mean(xData(:,:,1), 1) )) );
     uStep = max(abs(uData(:)));
 
     scaleFactor = 0.8 * xStep/uStep;


### PR DESCRIPTION
This PR fix the [issue #453](https://github.com/plotly/plotly_matlab/issues/453)

## Test code

```
[x, y, z] = meshgrid(-0.8:0.2:0.8, -0.8:0.2:0.8, -0.8:0.8:0.8);

u = sin(pi*x).*cos(pi*y).*cos(pi*z);
v = -cos(pi*x).*sin(pi*y).*cos(pi*z);
w = sqrt(2/3)*cos(pi*x).*cos(pi*y).*sin(pi*z);

figure
quiver3(x, y, z, u, v, z)

axis([-1 1 -1 1 -1 1])

title('Turbulence Values')
xlabel('x')
ylabel('x')
zlabel('z')

fig2plotly(gcf);
```

<img width="1500" alt="Screen Shot 2021-10-23 at 12 13 06 PM" src="https://user-images.githubusercontent.com/56391490/138563760-e15ec253-073e-4015-923e-50cf6a109181.png">

