### PR TITLE
fix issue #451

### DIFF
--- a/plotly/plotlyfig_aux/handlegraphics/updateScatter.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateScatter.m
@@ -23,6 +23,8 @@ function updateScatter(obj,scatterIndex)
     else
         obj.data{scatterIndex}.type = 'scatter3d';
         obj.data{scatterIndex}.scene = sprintf('scene%d', xSource);
+
+        updateScene(obj, scatterIndex);
     end
 
     obj.data{scatterIndex}.mode = 'markers';
@@ -48,7 +50,7 @@ function updateScatter(obj,scatterIndex)
     markerLineColor = obj.data{scatterIndex}.marker.line.color;
 
     if length(markerSize) == 1
-        obj.data{scatterIndex}.marker.size = markerSize * 0.15;
+        obj.data{scatterIndex}.marker.size = markerSize * 0.11;
     end
 
     if length(markerColor) == 1 
@@ -75,6 +77,118 @@ function updateScatter(obj,scatterIndex)
 
         obj.data{scatterIndex}.showlegend = showleg;
     end
+
+    %-------------------------------------------------------------------------%
+end
+
+function updateScene(obj, dataIndex)
+
+    %-------------------------------------------------------------------------%
+
+    %-INITIALIZATIONS-%
+    axIndex = obj.getAxisIndex(obj.State.Plot(dataIndex).AssociatedAxis);
+    plotData = get(obj.State.Plot(dataIndex).Handle);
+    axisData = get(plotData.Parent);
+    [xSource, ~] = findSourceAxis(obj, axIndex);
+    scene = eval( sprintf('obj.layout.scene%d', xSource) );
+
+    cameraTarget = axisData.CameraTarget;
+    position = axisData.Position;
+    aspectRatio = axisData.PlotBoxAspectRatio;
+    cameraPosition = axisData.CameraPosition;
+    dataAspectRatio = axisData.DataAspectRatio;
+    cameraUpVector = axisData.CameraUpVector;
+    cameraEye = cameraPosition./dataAspectRatio;
+    normFac = min(cameraTarget) / max(cameraTarget);
+    normFac = 1.1 * normFac * abs(min(cameraEye));
+
+    %-------------------------------------------------------------------------%
+
+    %-aspect ratio-%
+    scene.aspectratio.x = 1.0*aspectRatio(1);
+    scene.aspectratio.y = 1.0*aspectRatio(2);
+    scene.aspectratio.z = 1.0*aspectRatio(3);
+
+    %-camera eye-%
+    scene.camera.eye.x = cameraEye(1) / normFac;
+    scene.camera.eye.y = cameraEye(2) / normFac;
+    scene.camera.eye.z = cameraEye(3) / normFac;
+
+    %-camera up-%
+    scene.camera.up.x = cameraUpVector(1); 
+    scene.camera.up.y = cameraUpVector(2);
+    scene.camera.up.z = cameraUpVector(3);
+
+    %-------------------------------------------------------------------------%
+
+    %-scene axis configuration-%
+    rangeFac = 0.0;
+
+    xRange = range(axisData.XLim);
+    scene.xaxis.range(1) = axisData.XLim(1) - rangeFac * xRange;
+    scene.xaxis.range(2) = axisData.XLim(2) + rangeFac * xRange;
+
+    yRange = range(axisData.YLim);
+    scene.yaxis.range(1) = axisData.YLim(1) - rangeFac * yRange;
+    scene.yaxis.range(2) = axisData.YLim(2) + rangeFac * yRange;
+
+    zRange = range(axisData.ZLim);
+    scene.zaxis.range(1) = axisData.ZLim(1) - rangeFac * zRange;
+    scene.zaxis.range(2) = axisData.ZLim(2) + rangeFac * zRange;
+
+    scene.xaxis.zeroline = false;
+    scene.yaxis.zeroline = false;
+    scene.zaxis.zeroline = false;
+
+    scene.xaxis.showline = true;
+    scene.yaxis.showline = true;
+    scene.zaxis.showline = true;
+
+    scene.xaxis.ticklabelposition = 'outside';
+    scene.yaxis.ticklabelposition = 'outside';
+    scene.zaxis.ticklabelposition = 'outside';
+
+    scene.xaxis.title = axisData.XLabel.String;
+    scene.yaxis.title = axisData.YLabel.String;
+    scene.zaxis.title = axisData.ZLabel.String;
+
+    scene.xaxis.titlefont.color = 'rgba(0,0,0,1)';
+    scene.yaxis.titlefont.color = 'rgba(0,0,0,1)';
+    scene.zaxis.titlefont.color = 'rgba(0,0,0,1)';
+    scene.xaxis.titlefont.size = axisData.XLabel.FontSize;
+    scene.yaxis.titlefont.size = axisData.YLabel.FontSize;
+    scene.zaxis.titlefont.size = axisData.ZLabel.FontSize;
+    scene.xaxis.titlefont.family = matlab2plotlyfont(axisData.XLabel.FontName);
+    scene.yaxis.titlefont.family = matlab2plotlyfont(axisData.YLabel.FontName);
+    scene.zaxis.titlefont.family = matlab2plotlyfont(axisData.ZLabel.FontName);
+
+    %-tick labels-%
+    scene.xaxis.tickvals = axisData.XTick;
+    scene.xaxis.ticktext = axisData.XTickLabel;
+    scene.yaxis.tickvals = axisData.YTick;
+    scene.yaxis.ticktext = axisData.YTickLabel;
+    scene.zaxis.tickvals = axisData.ZTick;
+    scene.zaxis.ticktext = axisData.ZTickLabel;
+
+    scene.xaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.yaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.zaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.xaxis.tickfont.size = axisData.FontSize;
+    scene.yaxis.tickfont.size = axisData.FontSize;
+    scene.zaxis.tickfont.size = axisData.FontSize;
+    scene.xaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+    scene.yaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+    scene.zaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+
+    %-grid-%
+    if strcmp(axisData.XGrid, 'off'), scene.xaxis.showgrid = false; end
+    if strcmp(axisData.YGrid, 'off'), scene.yaxis.showgrid = false; end
+    if strcmp(axisData.ZGrid, 'off'), scene.zaxis.showgrid = false; end
+
+    %-------------------------------------------------------------------------%
+
+    %-SET SCENE TO LAYOUT-%
+    obj.layout = setfield(obj.layout, sprintf('scene%d', xSource), scene);
 
     %-------------------------------------------------------------------------%
 end


### PR DESCRIPTION
This PR fix the [issue #451](https://github.com/plotly/plotly_matlab/issues/451)

Now when we use following code

```
load imports-85
[coeff,score,latent,tsquared,explained] = pca(X(:,3:15));

scatter3(score(:,1),score(:,2),score(:,3))
axis equal
xlabel('1st Principal Component')
ylabel('2nd Principal Component')
zlabel('3rd Principal Component')

fig2plotly(gcf, 'offline', 'false');
```

we will get the following 

<img width="1548" alt="Screen Shot 2021-10-23 at 1 08 56 PM" src="https://user-images.githubusercontent.com/56391490/138565554-b9543805-337d-4971-b58d-f12100c15454.png">

Here the link to chart studio
https://chart-studio.plotly.com/~galvisgilberto/4668/#/