### PR TITLE
fix issue related to plot3 functionality

### DIFF
--- a/plotly/plotlyfig_aux/handlegraphics/updateLineseries.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateLineseries.m
@@ -139,15 +139,20 @@ function updateLineseries(obj, plotIndex)
     obj.PlotOptions.is3d = false; % by default
 
     if isfield(plotData,'ZData')
+        zData = plotData.ZData;
+        if isduration(zData) || isdatetime(zData), zData = datenum(zData); end
+
+        numbset = unique(zData);
         
-        numbset = unique(plotData.ZData);
-        
-        if any(plotData.ZData) && length(numbset)>1
+        if any(zData) && length(numbset)>1
             %-scatter z-%
-            obj.data{plotIndex}.z = plotData.ZData;
+            obj.data{plotIndex}.z = zData;
             
             %-overwrite type-%
             obj.data{plotIndex}.type = 'scatter3d';
+            obj.data{plotIndex}.scene = sprintf('scene%d', xsource);
+
+            updateScene(obj, plotIndex);
             
             %-flag to manage 3d plots-%
             obj.PlotOptions.is3d = true;
@@ -205,5 +210,162 @@ function updateLineseries(obj, plotIndex)
     end
 
     %-------------------------------------------------------------------------%
+end
 
+function updateScene(obj, dataIndex)
+
+    %-------------------------------------------------------------------------%
+
+    %-INITIALIZATIONS-%
+    axIndex = obj.getAxisIndex(obj.State.Plot(dataIndex).AssociatedAxis);
+    plotData = get(obj.State.Plot(dataIndex).Handle);
+    axisData = get(plotData.Parent);
+    [xSource, ~] = findSourceAxis(obj, axIndex);
+    scene = eval( sprintf('obj.layout.scene%d', xSource) );
+
+    cameraTarget = axisData.CameraTarget;
+    position = axisData.Position;
+    aspectRatio = axisData.PlotBoxAspectRatio;
+    cameraPosition = axisData.CameraPosition;
+    dataAspectRatio = axisData.DataAspectRatio;
+    cameraUpVector = axisData.CameraUpVector;
+    cameraEye = cameraPosition./dataAspectRatio;
+    normFac = 0.7 * abs(min(cameraEye));
+
+    %-------------------------------------------------------------------------%
+
+    %-aspect ratio-%
+    scene.aspectratio.x = 1.0*aspectRatio(1);
+    scene.aspectratio.y = 1.0*aspectRatio(2);
+    scene.aspectratio.z = 1.0*aspectRatio(3);
+
+    %-camera eye-%
+    scene.camera.eye.x = cameraEye(1) / normFac;
+    scene.camera.eye.y = cameraEye(2) / normFac;
+    scene.camera.eye.z = cameraEye(3) / normFac;
+
+    %-camera up-%
+    scene.camera.up.x = cameraUpVector(1); 
+    scene.camera.up.y = cameraUpVector(2);
+    scene.camera.up.z = cameraUpVector(3);
+
+    %-------------------------------------------------------------------------%
+
+    %-scene axis configuration-%
+    xRange = axisData.XLim;
+    if isduration(xRange) || isdatetime(xRange), xRange = datenum(xRange); end
+    scene.xaxis.range = xRange;
+
+    yRange = axisData.YLim;
+    if isduration(yRange) || isdatetime(yRange), yRange = datenum(yRange); end
+    scene.yaxis.range = yRange;
+
+    zRange = axisData.ZLim;
+    if isduration(zRange) || isdatetime(zRange), zRange = datenum(zRange); end
+    scene.zaxis.range = zRange;
+
+    scene.xaxis.zeroline = false;
+    scene.yaxis.zeroline = false;
+    scene.zaxis.zeroline = false;
+
+    scene.xaxis.showline = true;
+    scene.yaxis.showline = true;
+    scene.zaxis.showline = true;
+
+    scene.xaxis.ticklabelposition = 'outside';
+    scene.yaxis.ticklabelposition = 'outside';
+    scene.zaxis.ticklabelposition = 'outside';
+
+    scene.xaxis.title = axisData.XLabel.String;
+    scene.yaxis.title = axisData.YLabel.String;
+    scene.zaxis.title = axisData.ZLabel.String;
+
+    scene.xaxis.titlefont.color = 'rgba(0,0,0,1)';
+    scene.yaxis.titlefont.color = 'rgba(0,0,0,1)';
+    scene.zaxis.titlefont.color = 'rgba(0,0,0,1)';
+    scene.xaxis.titlefont.size = axisData.XLabel.FontSize;
+    scene.yaxis.titlefont.size = axisData.YLabel.FontSize;
+    scene.zaxis.titlefont.size = axisData.ZLabel.FontSize;
+    scene.xaxis.titlefont.family = matlab2plotlyfont(axisData.XLabel.FontName);
+    scene.yaxis.titlefont.family = matlab2plotlyfont(axisData.YLabel.FontName);
+    scene.zaxis.titlefont.family = matlab2plotlyfont(axisData.ZLabel.FontName);
+
+    %-tick labels-%
+    xTick = axisData.XTick;
+    if isduration(xTick) || isdatetime(xTick)
+        xTickChar = char(xTick);
+        xTickLabel = axisData.XTickLabel;
+
+        for n = 1:length(xTickLabel)
+            for m = 1:size(xTickChar, 1)
+                if ~isempty(strfind(string(xTickChar(m, :)), xTickLabel{n}))
+                    idx(n) = m;
+                end
+            end
+        end
+
+        xTick = datenum(xTick(idx));
+    end
+
+    yTick = axisData.YTick;
+    if isduration(yTick) || isdatetime(yTick)
+        yTickChar = char(yTick);
+        yTickLabel = axisData.YTickLabel;
+
+        for n = 1:length(yTickLabel)
+            for m = 1:size(yTickChar, 1)
+                if ~isempty(strfind(string(yTickChar(m, :)), yTickLabel{n}))
+                    idx(n) = m;
+                end
+            end
+        end
+
+        yTick = datenum(yTick(idx));
+    end
+
+
+    zTick = axisData.ZTick;
+    if isduration(zTick) || isdatetime(zTick)
+        zTickChar = char(zTick);
+        zTickLabel = axisData.ZTickLabel;
+
+        for n = 1:length(zTickLabel)
+            for m = 1:size(zTickChar, 1)
+                if ~isempty(strfind(string(zTickChar(m, :)), zTickLabel{n}))
+                    idx(n) = m;
+                end
+            end
+        end
+
+        zTick = datenum(zTick(idx));
+    end
+
+    scene.xaxis.tickvals = xTick;
+    scene.xaxis.ticktext = axisData.XTickLabel;
+    scene.yaxis.tickvals = yTick;
+    scene.yaxis.ticktext = axisData.YTickLabel;
+    scene.zaxis.tickvals = zTick;
+    scene.zaxis.ticktext = axisData.ZTickLabel;
+
+    scene.xaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.yaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.zaxis.tickcolor = 'rgba(0,0,0,1)';
+    scene.xaxis.tickfont.size = axisData.FontSize;
+    scene.yaxis.tickfont.size = axisData.FontSize;
+    scene.zaxis.tickfont.size = axisData.FontSize;
+    scene.xaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+    scene.yaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+    scene.zaxis.tickfont.family = matlab2plotlyfont(axisData.FontName);
+
+    %-grid-%
+    if strcmp(axisData.XGrid, 'off'), scene.xaxis.showgrid = false; end
+    if strcmp(axisData.YGrid, 'off'), scene.yaxis.showgrid = false; end
+    if strcmp(axisData.ZGrid, 'off'), scene.zaxis.showgrid = false; end
+
+    %-------------------------------------------------------------------------%
+
+    %-SET SCENE TO LAYOUT-%
+    obj.layout = setfield(obj.layout, sprintf('scene%d', xSource), scene);
+
+    %-------------------------------------------------------------------------%
 end

--- a/plotly/plotlyfig_aux/helpers/extractLineMarker.m
+++ b/plotly/plotlyfig_aux/helpers/extractLineMarker.m
@@ -20,6 +20,10 @@ marker = struct();
 %-MARKER SIZE-%
 marker.size = line_data.MarkerSize;
 
+if length(marker.size) == 1
+    marker.size = 0.6*marker.size;
+end
+
 %-------------------------------------------------------------------------%
 
 %-MARKER SYMBOL-%
@@ -28,7 +32,6 @@ if ~strcmp(line_data.Marker,'none')
     switch line_data.Marker
         case '.'
             marksymbol = 'circle';
-            marker.size = 0.4*line_data.MarkerSize;
         case 'o'
             marksymbol = 'circle';
         case 'x'


### PR DESCRIPTION
This PR fix issue realted to following code

```
x = rand(1,10);
y = rand(1,10);
z = duration(rand(10,1),randi(60,10,1),randi(60,10,1));

plot3(x,y,z,'o','DurationTickFormat','mm:ss');
xlabel('X');
ylabel('Y');
zlabel('Duration');
grid on;

fig2plotly(gcf);
```

Now the result is the follow

<img width="1555" alt="Screen Shot 2021-10-24 at 11 17 51 PM" src="https://user-images.githubusercontent.com/56391490/138629917-8978b600-a062-4a59-b459-6bf20c3ccff6.png">
