### PR TITLE
fix write to svg file bug

### DIFF
--- a/plotly/export_fig2/write_image.m
+++ b/plotly/export_fig2/write_image.m
@@ -103,9 +103,15 @@ end
 if output.code ~= 0
     fprintf('\nError: %s\n',output.message);
 else
-    out=unicode2native(output.result,'UTF-8');
-    out=base64decode(out);
-    f=fopen(char(filename),'wb');
-    fwrite(f,out);
-    fclose(f);
+    if output.format == "svg"
+        f=fopen(char(filename),'w');
+        fwrite(f,output.result);
+        fclose(f);
+    else
+        out=unicode2native(output.result,'UTF-8');
+        out=base64decode(out);
+        f=fopen(char(filename),'wb');
+        fwrite(f,out);
+        fclose(f);
+    end
 end


### PR DESCRIPTION
1. matlab report:  `Error using base64decode (line 60)`; 
2. export svg cannot open rightly, becuase svg source are garbled.